### PR TITLE
feat[Core]: Admin and User Metadata for transactional ressources and users (#5897)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'pg', '~> 1.0', require: false if dbs.match?(/all|postgres/)
 gem 'fast_sqlite', require: false if dbs.match?(/all|sqlite/)
 gem 'sqlite3', '>= 2.1', require: false if dbs.match?(/all|sqlite/)
 
-
 gem 'database_cleaner', '~> 2.0', require: false
 gem 'rspec-activemodel-mocks', '~> 1.1', require: false
 gem 'rspec-rails', '~> 6.0.3', require: false

--- a/api/app/controllers/spree/api/line_items_controller.rb
+++ b/api/app/controllers/spree/api/line_items_controller.rb
@@ -15,8 +15,10 @@ module Spree
           @line_item = @order.contents.add(
             variant,
             params[:line_item][:quantity] || 1,
-            options: line_item_params[:options].to_h
+            options: line_item_params[:options].to_h,
+            **extract_metadata
           )
+
           respond_with(@line_item, status: 201, default_template: :show)
         rescue ActiveRecord::RecordInvalid => error
           invalid_resource!(error.record)
@@ -56,8 +58,19 @@ module Spree
         { line_items_attributes: {
             id: params[:id],
             quantity: params[:line_item][:quantity],
-            options: line_item_params[:options] || {}
+            options: line_item_params[:options] || {},
+            **extract_metadata
         } }
+      end
+
+      def extract_metadata
+        metadata = { customer_metadata: line_item_params[:customer_metadata] }
+
+        if @current_user_roles&.include?("admin")
+          metadata[:admin_metadata] = line_item_params[:admin_metadata]
+        end
+
+        metadata
       end
 
       def line_item_params

--- a/api/app/controllers/spree/api/orders_controller.rb
+++ b/api/app/controllers/spree/api/orders_controller.rb
@@ -112,10 +112,17 @@ module Spree
       def order_params
         if params[:order]
           normalize_params
+          prevent_customer_metadata_update
           params.require(:order).permit(permitted_order_attributes)
         else
           {}
         end
+      end
+
+      def prevent_customer_metadata_update
+        return unless @order&.completed? && cannot?(:admin, Spree::Order)
+
+        params[:order].delete(:customer_metadata) if params[:order]
       end
 
       def normalize_params

--- a/api/app/helpers/spree/api/api_helpers.rb
+++ b/api/app/helpers/spree/api/api_helpers.rb
@@ -43,6 +43,16 @@ module Spree
         end
       end
 
+      Spree::Api::Config.metadata_api_parameters.each do |method_name, resource|
+        define_method("#{method_name}_attributes") do
+          authorized_attributes(resource, "#{method_name}_attributes")
+        end
+      end
+
+      def authorized_attributes(resource, config_attribute)
+        can?(:admin, resource) ? Spree::Api::Config.public_send(config_attribute) + [:admin_metadata] : Spree::Api::Config.public_send(config_attribute)
+      end
+
       def required_fields_for(model)
         required_fields = model._validators.select do |_field, validations|
           validations.any? { |validation| validation.is_a?(ActiveModel::Validations::PresenceValidator) }

--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -41,6 +41,28 @@ module Spree
 
     preference :line_item_attributes, :array, default: [:id, :quantity, :price, :variant_id, :customer_metadata]
 
+    # Spree::Api::Config.metadata_api_parameters contains the models
+    # to which the admin_metadata attribute is added
+    preference :metadata_api_parameters, :array, default: [
+      [:order, 'Spree::Order'],
+      [:customer_return, 'Spree::CustomerReturn'],
+      [:payment, 'Spree::Payment'],
+      [:return_authorization, 'Spree::ReturnAuthorization'],
+      [:shipment, 'Spree::Shipment'],
+      [:user, 'Spree.user_class'],
+      [:line_item, 'Spree::LineItem']
+    ]
+
+    # Spree::Api::Config.metadata_permit_parameters contains the models
+    # to which the admin_metadata attribute is permitted
+    preference :metadata_permit_parameters, :array, default: [
+      :Order,
+      :CustomerReturn,
+      :Payment,
+      :ReturnAuthorization,
+      :Shipment
+    ]
+
     preference :option_type_attributes, :array, default: [:id, :name, :presentation, :position]
 
     preference :payment_attributes, :array, default: [

--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -36,22 +36,22 @@ module Spree
       :covered_by_store_credit, :display_total_applicable_store_credit,
       :order_total_after_store_credit, :display_order_total_after_store_credit,
       :total_applicable_store_credit, :display_total_available_store_credit,
-      :display_store_credit_remaining_after_capture, :canceler_id
+      :display_store_credit_remaining_after_capture, :canceler_id, :customer_metadata
     ]
 
-    preference :line_item_attributes, :array, default: [:id, :quantity, :price, :variant_id]
+    preference :line_item_attributes, :array, default: [:id, :quantity, :price, :variant_id, :customer_metadata]
 
     preference :option_type_attributes, :array, default: [:id, :name, :presentation, :position]
 
     preference :payment_attributes, :array, default: [
       :id, :source_type, :source_id, :amount, :display_amount,
       :payment_method_id, :state, :avs_response, :created_at,
-      :updated_at
+      :updated_at, :customer_metadata
     ]
 
     preference :payment_method_attributes, :array, default: [:id, :name, :description]
 
-    preference :shipment_attributes, :array, default: [:id, :tracking, :tracking_url, :number, :cost, :shipped_at, :state]
+    preference :shipment_attributes, :array, default: [:id, :tracking, :tracking_url, :number, :cost, :shipped_at, :state, :customer_metadata]
 
     preference :taxonomy_attributes, :array, default: [:id, :name]
 
@@ -81,11 +81,11 @@ module Spree
     ]
 
     preference :customer_return_attributes, :array, default: [
-      :id, :number, :stock_location_id, :created_at, :updated_at
+      :id, :number, :stock_location_id, :created_at, :updated_at, :customer_metadata
     ]
 
     preference :return_authorization_attributes, :array, default: [
-      :id, :number, :state, :order_id, :memo, :created_at, :updated_at
+      :id, :number, :state, :order_id, :memo, :created_at, :updated_at, :customer_metadata
     ]
 
     preference :creditcard_attributes, :array, default: [
@@ -96,7 +96,7 @@ module Spree
       :id, :month, :year, :cc_type, :last_digits, :name
     ]
 
-    preference :user_attributes, :array, default: [:id, :email, :created_at, :updated_at]
+    preference :user_attributes, :array, default: [:id, :email, :created_at, :updated_at, :customer_metadata]
 
     preference :property_attributes, :array, default: [:id, :name, :presentation]
 
@@ -132,7 +132,7 @@ module Spree
 
     preference :store_credit_history_attributes, :array, default: [
       :display_amount, :display_user_total_amount, :display_action,
-      :display_event_date, :display_remaining_amount
+      :display_event_date, :display_remaining_amount, :customer_metadata
     ]
 
     preference :variant_property_attributes, :array, default: [

--- a/api/spec/requests/spree/api/customer_returns_spec.rb
+++ b/api/spec/requests/spree/api/customer_returns_spec.rb
@@ -59,6 +59,14 @@ module Spree::Api
         expect(json_response).to have_attributes(attributes)
       end
 
+      it "can view admin_metadata" do
+        customer_return = FactoryBot.create(:customer_return)
+
+        get spree.api_order_customer_return_path(customer_return.order, customer_return.id)
+
+        expect(json_response).to have_key('admin_metadata')
+      end
+
       it "can get a list of customer returns" do
         FactoryBot.create(:customer_return, shipped_order: order)
         FactoryBot.create(:customer_return, shipped_order: order)
@@ -97,7 +105,7 @@ module Spree::Api
       it "can learn how to create a new customer return" do
         get spree.new_api_order_customer_return_path(order)
 
-        expect(json_response["attributes"]).to eq(["id", "number", "stock_location_id", "created_at", "updated_at"])
+        expect(json_response["attributes"]).to eq(["id", "number", "stock_location_id", "created_at", "updated_at", "customer_metadata", "admin_metadata"])
       end
 
       it "can update a customer return" do
@@ -110,6 +118,23 @@ module Spree::Api
         expect(response.status).to eq(200)
         expect(json_response).to have_attributes(attributes)
         expect(json_response["stock_location_id"]).to eq final_stock_location.id
+      end
+
+      it "can update a customer return admin_metadata" do
+        initial_stock_location = FactoryBot.create(:stock_location)
+        final_stock_location = FactoryBot.create(:stock_location)
+        customer_return = FactoryBot.create(:customer_return, stock_location: initial_stock_location)
+
+        put spree.api_order_customer_return_path(customer_return.order, customer_return.id),
+        params: {
+          order_id: customer_return.order.number,
+          customer_return: { stock_location_id: final_stock_location.id, admin_metadata: { 'order_number' => 'PN345678' } }
+        }
+
+        expect(response.status).to eq(200)
+        expect(json_response).to have_attributes(attributes)
+        expect(json_response["stock_location_id"]).to eq final_stock_location.id
+        expect(json_response["admin_metadata"]).to eq({ 'order_number' => 'PN345678' })
       end
 
       context "when creating new return items" do

--- a/api/spec/requests/spree/api/line_items_spec.rb
+++ b/api/spec/requests/spree/api/line_items_spec.rb
@@ -228,6 +228,34 @@ module Spree::Api
       end
     end
 
+    context "as an admin" do
+      sign_in_as_admin!
+
+      it "can see admin_metadata" do
+        post spree.api_order_line_items_path(order),
+        params: {
+          line_item: { variant_id: product.master.to_param, quantity: 1 },
+          order_token: order.guest_token
+        }
+
+        expect(response.status).to eq(201)
+        expect(json_response).to have_key('admin_metadata')
+      end
+
+      it "allows creating line item with customer metadata and admin metadata" do
+        post spree.api_order_line_items_path(order),
+        params: {
+          line_item: { variant_id: product.master.to_param,
+                       quantity: 1,
+                       customer_metadata: { "Company" => "Sample Company" },
+                       admin_metadata: { "discount" => "not_applicable" } }
+        }
+
+        expect(json_response['customer_metadata']).to eq({ "Company" => "Sample Company" })
+        expect(json_response['admin_metadata']).to eq({ "discount" => "not_applicable" })
+      end
+    end
+
     context "as just another user" do
       before do
         user = create(:user)

--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -128,6 +128,17 @@ module Spree::Api
 
           expect(json_response).not_to have_key('admin_metadata')
         end
+
+        it "cannot update customer metadata if the order is complete" do
+          order = create(:order)
+          order.completed_at = Time.current
+          order.state = 'complete'
+          order.save!
+
+          put spree.api_order_path(order), params: { order: attributes_with_metadata }
+
+          expect(json_response['customer_metadata']).to eq({})
+        end
       end
 
       context "when the current user can administrate the order" do

--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -987,6 +987,32 @@ module Spree::Api
           expect(json_response['error']).to eq(I18n.t(:could_not_transition, scope: "spree.api", resource: 'order'))
           expect(response.status).to eq(422)
         end
+
+        it "can update a order admin_metadata" do
+          put spree.api_order_path(order), params: { order: { admin_metadata: { 'order_number' => 'PN345678' } } }
+
+          expect(response.status).to eq(200)
+
+          expect(json_response["admin_metadata"]).to eq({ 'order_number' => 'PN345678' })
+        end
+
+        it "can update customer metadata if the order is complete" do
+          order = create(:order)
+          order.completed_at = Time.current
+          order.state = 'complete'
+          order.save!
+
+          put spree.api_order_path(order), params: { order: { customer_metadata: { 'Note' => 'Do not ring the bell' }, admin_metadata: { 'order_number' => 'PN345678' } } }
+
+          expect(json_response['customer_metadata']).to eq({ 'Note' => 'Do not ring the bell' })
+          expect(json_response["admin_metadata"]).to eq({ 'order_number' => 'PN345678' })
+        end
+
+        it "can view admin_metadata" do
+          get spree.api_order_path(order)
+
+          expect(json_response).to have_key('admin_metadata')
+        end
       end
 
       context "can cancel an order" do

--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -14,7 +14,7 @@ module Spree::Api
        :user_id, :created_at, :updated_at,
        :completed_at, :payment_total, :shipment_state,
        :payment_state, :email, :special_instructions,
-       :total_quantity, :display_item_total, :currency]
+       :total_quantity, :display_item_total, :currency, :customer_metadata]
     }
 
     let(:address_params) { { country_id: Country.first.id, state_id: State.first.id } }
@@ -76,6 +76,57 @@ module Spree::Api
               }.not_to change { Spree::Payment.count }
             end
           end
+        end
+      end
+
+      context "when the user is not admin but has ability to create and update orders" do
+        custom_authorization! do |_|
+          can [:update, :create], Spree::Order
+        end
+
+        let(:attributes_with_metadata) {
+          { email: "foo@foobar.com",
+            customer_metadata: { 'Note' => 'Do not ring the bell' },
+            admin_metadata: { 'Customer_type' => 'Corporate giant' } }
+        }
+
+        let(:order_update_data_with_admin_metadata){
+          {
+            email: "new_email@update.com",
+            admin_metadata: { 'Serial_number' => 'Sn98765' }
+          }
+        }
+
+        it "allows creating order with customer metadata but not admin metadata" do
+          post spree.api_orders_path, params: { order: attributes_with_metadata }
+
+          expect(json_response['customer_metadata']).to eq({ 'Note' => 'Do not ring the bell' })
+          expect(json_response).not_to have_key('admin_metadata')
+
+          created_order = Spree::Order.last
+
+          expect(created_order.admin_metadata).to eq({})
+        end
+
+        it "allows updating order but ignores admin metadata" do
+          order = create(:order)
+
+          put spree.api_order_path(order), params: { order: order_update_data_with_admin_metadata }
+
+          expect(json_response['email']).to eq( "new_email@update.com" )
+          expect(json_response).not_to have_key('admin_metadata')
+
+          order.reload
+
+          expect(order.admin_metadata).to eq({})
+        end
+
+        it "cannot view admin_metadata" do
+          allow_any_instance_of(Spree::Order).to receive_messages user: current_api_user
+
+          get spree.api_order_path(order)
+
+          expect(json_response).not_to have_key('admin_metadata')
         end
       end
 

--- a/api/spec/requests/spree/api/payments_spec.rb
+++ b/api/spec/requests/spree/api/payments_spec.rb
@@ -187,6 +187,26 @@ module Spree::Api
               expect(response.status).to eq(403)
               expect(json_response["error"]).to eq("This payment cannot be updated because it is completed.")
             end
+
+            it "can update a payment admin_metadata" do
+              payment.update(state: 'pending')
+
+              put spree.api_order_payment_path(order, payment),
+              params: {
+                payment: {
+                  amount: 2.01,
+                  admin_metadata: { 'order_number' => 'PN345678' }
+                }
+              }
+
+              expect(response.status).to eq(200)
+              expect(json_response["admin_metadata"]).to eq({ 'order_number' => 'PN345678' })
+            end
+
+            it "can view admin_metadata" do
+              get spree.api_order_payments_path(order)
+              expect(json_response["payments"].first).to have_key('admin_metadata')
+            end
           end
         end
 

--- a/api/spec/requests/spree/api/shipments_spec.rb
+++ b/api/spec/requests/spree/api/shipments_spec.rb
@@ -92,6 +92,23 @@ module Spree::Api
         expect(json_response['stock_location_name']).to eq(stock_location.name)
       end
 
+      it "can update a shipment and it's metadata" do
+        params = {
+          shipment: {
+            stock_location_id: stock_location.to_param,
+            admin_metadata: { 'delivery_type' => 'express' },
+            customer_metadata: { 'timing' => 'standard' }
+          }
+        }
+
+        put(spree.api_shipment_path(shipment), params:)
+
+        expect(response.status).to eq(200)
+        expect(json_response['stock_location_name']).to eq(stock_location.name)
+        expect(json_response["admin_metadata"]).to eq({ 'delivery_type' => 'express' })
+        expect(json_response["customer_metadata"]).to eq({ 'timing' => 'standard' })
+      end
+
       it "can make a shipment ready" do
         allow_any_instance_of(Spree::Order).to receive_messages(paid?: true, complete?: true)
         put spree.ready_api_shipment_path(shipment)

--- a/api/spec/requests/spree/api/users_spec.rb
+++ b/api/spec/requests/spree/api/users_spec.rb
@@ -188,6 +188,18 @@ module Spree::Api
         expect(json_response['users'].first['email']).to eq expected_result.email
       end
 
+      it 'can view admin_metadata' do
+        allow(Spree::LegacyUser).to receive(:find_by).with(hash_including(:spree_api_key)) { current_api_user }
+
+        2.times { create(:user) }
+
+        get spree.api_users_path
+        expect(Spree.user_class.count).to eq 2
+        expect(json_response['count']).to eq 2
+        expect(json_response['users'].size).to eq 2
+        expect(json_response['users'].first).to have_key('admin_metadata')
+      end
+
       it "can create" do
         post spree.api_users_path, params: { user: { email: "new@example.com", password: 'spree123', password_confirmation: 'spree123' } }
         expect(json_response).to have_attributes(attributes)
@@ -198,6 +210,14 @@ module Spree::Api
         post spree.api_users_path, params: { user: { email: "existing@example.com" } }
         expect(json_response).to have_attributes(attributes)
         expect(response.status).to eq(201)
+      end
+
+      it "can update admin_metadata" do
+        post spree.api_users_path, params: { user: { email: "existing@example.com", admin_metadata: { 'user_type' => 'regular' } } }
+
+        expect(json_response).to have_attributes(attributes)
+        expect(response.status).to eq(201)
+        expect(json_response["admin_metadata"]).to eq({ 'user_type' => 'regular' })
       end
 
       it "can destroy user without orders" do

--- a/api/spec/requests/spree/api/users_spec.rb
+++ b/api/spec/requests/spree/api/users_spec.rb
@@ -6,13 +6,27 @@ module Spree::Api
   describe 'Users', type: :request do
     let(:user) { create(:user, spree_api_key: SecureRandom.hex) }
     let(:stranger) { create(:user, email: 'stranger@example.com') }
-    let(:attributes) { [:id, :email, :created_at, :updated_at] }
+    let(:attributes) { [:id, :email, :created_at, :updated_at, :customer_metadata] }
 
     context "as a normal user" do
       it "can get own details" do
         get spree.api_user_path(user.id), params: { token: user.spree_api_key }
 
         expect(json_response['email']).to eq user.email
+      end
+
+      it "can view customer_metadata" do
+        get spree.api_user_path(user.id), params: { token: user.spree_api_key }
+
+        expect(json_response['email']).to eq user.email
+        expect(json_response).to have_key('customer_metadata')
+      end
+
+      it "cannot view admin_metadata" do
+        get spree.api_user_path(user.id), params: { token: user.spree_api_key }
+
+        expect(json_response['email']).to eq user.email
+        expect(json_response).not_to have_key('admin_metadata')
       end
 
       it "cannot get other users details" do
@@ -33,6 +47,18 @@ module Spree::Api
 
         post spree.api_users_path, params: { user: user_params, token: user.spree_api_key }
         expect(json_response['email']).to eq 'new@example.com'
+      end
+
+      it "can create a new user with customer_metadata" do
+        user_params = {
+          email: 'new@example.com', password: 'spree123', password_confirmation: 'spree123', customer_metadata: { 'username' => 'newuser' }
+        }
+
+        post spree.api_users_path, params: { user: user_params, token: user.spree_api_key }
+
+        expect(json_response['email']).to eq 'new@example.com'
+        expect(json_response['customer_metadata']).to eq({ 'username' => 'newuser' })
+        expect(json_response).not_to have_key('admin_metadata')
       end
 
       it "cannot create a new user with invalid attributes" do

--- a/bin/release/extract-pipeline-context
+++ b/bin/release/extract-pipeline-context
@@ -36,6 +36,7 @@ context_hash = {
 }
 
 warn "~~> Generating context..."
-context_hash.each { |k, v| warn "#{k}=#{v}" }
-
-context_hash.each { |k, v| puts "#{k}=#{v}" }
+context_hash.each { |k, v|
+  warn "#{k}=#{v}"
+  puts "#{k}=#{v}"
+}

--- a/core/app/helpers/spree/core/controller_helpers/strong_parameters.rb
+++ b/core/app/helpers/spree/core/controller_helpers/strong_parameters.rb
@@ -50,6 +50,7 @@ module Spree
           permitted_checkout_address_attributes +
             permitted_checkout_delivery_attributes +
             permitted_checkout_payment_attributes +
+            permitted_attributes.customer_metadata_attributes +
             permitted_checkout_confirm_attributes + [
             line_items_attributes: permitted_line_item_attributes
           ]

--- a/core/app/models/concerns/spree/metadata.rb
+++ b/core/app/models/concerns/spree/metadata.rb
@@ -8,7 +8,7 @@ module Spree
       attribute :customer_metadata, :json, default: {}
       attribute :admin_metadata, :json, default: {}
 
-      validate :validate_metadata_limits
+      validate :validate_metadata_limits, if: :validate_metadata_enabled?
     end
 
     class_methods do
@@ -18,6 +18,10 @@ module Spree
     end
 
     private
+
+    def validate_metadata_enabled?
+      Spree::Config.meta_data_validation_enabled
+    end
 
     def validate_metadata_limits
       self.class.meta_data_columns.each { |column| validate_metadata_column(column) }

--- a/core/app/models/concerns/spree/metadata.rb
+++ b/core/app/models/concerns/spree/metadata.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Spree
+  module Metadata
+    extend ActiveSupport::Concern
+
+    included do
+      attribute :customer_metadata, :json, default: {}
+      attribute :admin_metadata, :json, default: {}
+
+      validate :validate_metadata_limits
+    end
+
+    class_methods do
+      def meta_data_columns
+        %i[customer_metadata admin_metadata]
+      end
+    end
+
+    private
+
+    def validate_metadata_limits
+      self.class.meta_data_columns.each { |column| validate_metadata_column(column) }
+    end
+
+    def validate_metadata_column(column)
+      config = Spree::Config
+      metadata = send(column)
+
+      return if metadata.nil?
+
+      # Check for maximum number of keys
+      validate_metadata_keys_count(metadata, column, config.meta_data_max_keys)
+
+      # Check for maximum key and value size
+      metadata.each do |key, value|
+        validate_metadata_key(key, column, config.meta_data_max_key_length)
+        validate_metadata_value(key, value, column, config.meta_data_max_value_length)
+      end
+    end
+
+    def validate_metadata_keys_count(metadata, column, max_keys)
+      return unless metadata.keys.count > max_keys
+
+      errors.add(column, "must not have more than #{max_keys} keys")
+    end
+
+    def validate_metadata_key(key, column, max_key_length)
+      return unless key.to_s.length > max_key_length
+
+      errors.add(column, "key '#{key}' exceeds #{max_key_length} characters")
+    end
+
+    def validate_metadata_value(key, value, column, max_value_length)
+      return unless value.to_s.length > max_value_length
+
+      errors.add(column, "value for key '#{key}' exceeds #{max_value_length} characters")
+    end
+  end
+end

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -2,6 +2,8 @@
 
 module Spree
   class CustomerReturn < Spree::Base
+    include Metadata
+
     belongs_to :stock_location, optional: true
 
     has_many :return_items, inverse_of: :customer_return

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -7,6 +7,7 @@ module Spree
   #   spree_auth_devise)
   class LegacyUser < Spree::Base
     include UserMethods
+    include Metadata
 
     self.table_name = 'spree_users'
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -10,6 +10,8 @@ module Spree
   # promotion system.
   #
   class LineItem < Spree::Base
+    include Metadata
+
     belongs_to :order, class_name: "Spree::Order", inverse_of: :line_items, touch: true, optional: true
     belongs_to :variant, -> { with_discarded }, class_name: "Spree::Variant", inverse_of: :line_items, optional: true
     belongs_to :tax_category, class_name: "Spree::TaxCategory", optional: true

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -26,6 +26,7 @@ module Spree
     include ::Spree::Config.state_machines.order
 
     include Spree::Order::Payments
+    include Metadata
 
     class InsufficientStock < StandardError
       attr_reader :items

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -7,6 +7,7 @@ module Spree
   #
   class Payment < Spree::Base
     include Spree::Payment::Processing
+    include Metadata
 
     IDENTIFIER_CHARS    = (('A'..'Z').to_a + ('0'..'9').to_a - %w(0 1 I O)).freeze
     NON_RISKY_AVS_CODES = ['B', 'D', 'H', 'J', 'M', 'Q', 'T', 'V', 'X', 'Y'].freeze

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -2,6 +2,8 @@
 
 module Spree
   class Refund < Spree::Base
+    include Metadata
+
     belongs_to :payment, inverse_of: :refunds, optional: true
     belongs_to :reason, class_name: 'Spree::RefundReason', foreign_key: :refund_reason_id, optional: true
     belongs_to :reimbursement, inverse_of: :refunds, optional: true

--- a/core/app/models/spree/return_authorization.rb
+++ b/core/app/models/spree/return_authorization.rb
@@ -4,6 +4,8 @@ module Spree
   # Models the return of Inventory Units to a Stock Location for an Order.
   #
   class ReturnAuthorization < Spree::Base
+    include Metadata
+
     belongs_to :order, class_name: 'Spree::Order', inverse_of: :return_authorizations, optional: true
 
     has_many :return_items, inverse_of: :return_authorization, dependent: :destroy

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -4,6 +4,8 @@ module Spree
   # An order's planned shipments including tracking and cost.
   #
   class Shipment < Spree::Base
+    include Metadata
+
     belongs_to :order, class_name: 'Spree::Order', touch: true, inverse_of: :shipments, optional: true
     belongs_to :stock_location, class_name: 'Spree::StockLocation', optional: true
 

--- a/core/app/models/spree/simple_order_contents.rb
+++ b/core/app/models/spree/simple_order_contents.rb
@@ -85,8 +85,11 @@ module Spree
         adjustments: []
       )
 
+      permitted_attributes = Spree::PermittedAttributes.line_item_attributes.dup
+      permitted_attributes << { admin_metadata: {} } if options[:admin_metadata].present?
+
       line_item.quantity += quantity.to_i
-      line_item.options = ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes).to_h
+      line_item.options = ActionController::Parameters.new(options).permit(permitted_attributes).to_h
 
       line_item.target_shipment = options[:shipment]
       line_item.save!

--- a/core/app/models/spree/store_credit_event.rb
+++ b/core/app/models/spree/store_credit_event.rb
@@ -3,6 +3,7 @@
 module Spree
   class StoreCreditEvent < Spree::Base
     include Spree::SoftDeletable
+    include Metadata
 
     belongs_to :store_credit, optional: true
     belongs_to :originator, polymorphic: true, optional: true

--- a/core/db/migrate/20250129061658_add_metadata_to_spree_resources.rb
+++ b/core/db/migrate/20250129061658_add_metadata_to_spree_resources.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AddMetadataToSpreeResources < ActiveRecord::Migration[7.2]
+  def change
+    # List of Resources to add metadata columns to
+    %i[
+      spree_orders
+      spree_line_items
+      spree_shipments
+      spree_payments
+      spree_refunds
+      spree_customer_returns
+      spree_store_credit_events
+      spree_users
+      spree_return_authorizations
+    ].each do |table_name|
+      change_table table_name do |t|
+        # Check if the database supports jsonb for efficient querying
+        if t.respond_to?(:jsonb)
+          add_column table_name, :customer_metadata, :jsonb, default: {}
+          add_column table_name, :admin_metadata, :jsonb, default: {}
+        else
+          add_column table_name, :customer_metadata, :json
+          add_column table_name, :admin_metadata, :json
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -216,6 +216,19 @@ module Spree
     #   @return [Integer] Orders to show per-page in the admin (default: +15+)
     preference :orders_per_page, :integer, default: 15
 
+
+    # @!attribute [rw] meta_data_max_keys
+    #   @return [Integer] Maximum keys that can be allocated in customer and admin metadata column (default: +6+)
+    preference :meta_data_max_keys, :integer, default: 6
+
+    # @!attribute [rw] meta_data_max_key_length
+    #   @return [Integer] Maximum length that key can have in customer and admin metadata column (default: +16+)
+    preference :meta_data_max_key_length, :integer, default: 16
+
+    # @!attribute [rw] meta_data_max_value_length
+    #   @return [Integer] Maximum length that value can have in customer and admin metadata column (default: +256+)
+    preference :meta_data_max_value_length, :integer, default: 256
+
     # @!attribute [rw] properties_per_page
     #   @return [Integer] Properties to show per-page in the admin (default: +15+)
     preference :properties_per_page, :integer, default: 15

--- a/core/lib/spree/app_configuration.rb
+++ b/core/lib/spree/app_configuration.rb
@@ -216,6 +216,14 @@ module Spree
     #   @return [Integer] Orders to show per-page in the admin (default: +15+)
     preference :orders_per_page, :integer, default: 15
 
+    # @!attribute [rw] meta_data_validation_enabled
+    #   @return [Boolean] Indicates whether validation for customer and admin metadata columns is enabled.
+    #   When this is set to true, the following preferences will be used to validate the metadata:
+    #   - The maximum number of keys that can be added to the metadata columns (meta_data_max_keys).
+    #   - The maximum length of each key in the metadata columns (meta_data_max_key_length).
+    #   - The maximum length of each value in the metadata columns (meta_data_max_value_length).
+    #   (default: +true+)
+    preference :meta_data_validation_enabled, :boolean, default: false
 
     # @!attribute [rw] meta_data_max_keys
     #   @return [Integer] Maximum keys that can be allocated in customer and admin metadata column (default: +6+)

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -87,14 +87,13 @@ module Spree
     @@property_attributes = [:name, :presentation]
 
     @@return_authorization_attributes = [:memo, :stock_location_id, :return_reason_id,
-      customer_metadata: {},
-      return_items_attributes: [
-        :inventory_unit_id,
-        :exchange_variant_id,
-        :return_reason_id,
-        :preferred_reimbursement_type_id
-      ]
-    ]
+                                         customer_metadata: {},
+                                         return_items_attributes: [
+                                           :inventory_unit_id,
+                                           :exchange_variant_id,
+                                           :return_reason_id,
+                                           :preferred_reimbursement_type_id
+                                         ]]
 
     @@shipment_attributes = [
       :special_instructions, :stock_location_id, :id, :tracking,

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -14,6 +14,7 @@ module Spree
       :checkout_confirm_attributes,
       :credit_card_update_attributes,
       :customer_return_attributes,
+      :customer_metadata_attributes,
       :image_attributes,
       :inventory_unit_attributes,
       :line_item_attributes,
@@ -55,21 +56,23 @@ module Spree
       :stock_location_id, return_items_attributes: [
         :id, :inventory_unit_id, :return_authorization_id, :returned, :amount,
         :reception_status_event, :acceptance_status, :exchange_variant_id,
-        :resellable, :return_reason_id
+        :resellable, :return_reason_id, customer_metadata: {}
       ]
     ]
+
+    @@customer_metadata_attributes = [customer_metadata: {}]
 
     @@image_attributes = [:alt, :attachment, :position, :viewable_type, :viewable_id]
 
     @@inventory_unit_attributes = [:shipment, :variant_id]
 
-    @@line_item_attributes = [:id, :variant_id, :quantity]
+    @@line_item_attributes = [:id, :variant_id, :quantity, customer_metadata: {}]
 
     @@option_value_attributes = [:name, :presentation]
 
     @@option_type_attributes = [:name, :presentation, option_values_attributes: option_value_attributes]
 
-    @@payment_attributes = [:amount, :payment_method_id, :payment_method]
+    @@payment_attributes = [:amount, :payment_method_id, :payment_method, customer_metadata: {}]
 
     @@product_properties_attributes = [:property_name, :value, :position]
 
@@ -83,11 +86,19 @@ module Spree
 
     @@property_attributes = [:name, :presentation]
 
-    @@return_authorization_attributes = [:memo, :stock_location_id, :return_reason_id, return_items_attributes: [:inventory_unit_id, :exchange_variant_id, :return_reason_id, :preferred_reimbursement_type_id]]
+    @@return_authorization_attributes = [:memo, :stock_location_id, :return_reason_id,
+      customer_metadata: {},
+      return_items_attributes: [
+        :inventory_unit_id,
+        :exchange_variant_id,
+        :return_reason_id,
+        :preferred_reimbursement_type_id
+      ]
+    ]
 
     @@shipment_attributes = [
       :special_instructions, :stock_location_id, :id, :tracking,
-      :selected_shipping_rate_id
+      :selected_shipping_rate_id, customer_metadata: {}
     ]
 
     # month / year may be provided by some sources, or others may elect to use one field
@@ -126,7 +137,7 @@ module Spree
     # by changing a user with higher priveleges' email to one a lower-priveleged
     # admin owns. Creating a user with an email is handled separate at the
     # controller level.
-    @@user_attributes = [:password, :password_confirmation]
+    @@user_attributes = [:password, :password_confirmation, customer_metadata: {}]
 
     @@variant_attributes = [
       :name, :presentation, :cost_price, :lock_version,

--- a/core/spec/lib/spree/app_configuration_spec.rb
+++ b/core/spec/lib/spree/app_configuration_spec.rb
@@ -222,4 +222,22 @@ RSpec.describe Spree::AppConfiguration do
     expect(prefs.admin_vat_location.state_id).to eq(nil)
     expect(prefs.admin_vat_location.country_id).to eq(nil)
   end
+
+  describe '@meta_data_max_keys' do
+    it 'is 6 by default' do
+      expect(prefs[:meta_data_max_keys]).to eq(6)
+    end
+  end
+
+  describe '@meta_data_max_key_length' do
+    it 'is 16 by default' do
+      expect(prefs[:meta_data_max_key_length]).to eq(16)
+    end
+  end
+
+  describe '@meta_data_max_value_length' do
+    it 'is 256 by default' do
+      expect(prefs[:meta_data_max_value_length]).to eq(256)
+    end
+  end
 end

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -303,4 +303,6 @@ RSpec.describe Spree::CustomerReturn, type: :model do
       end
     end
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :customer_return
 end

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -189,4 +189,6 @@ RSpec.describe Spree::LineItem, type: :model do
       expect(subject.currency).to eq("USD")
     end
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :line_item
 end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -2145,4 +2145,6 @@ RSpec.describe Spree::Order, type: :model do
       it { is_expected.to eq(true) }
     end
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :order
 end

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -1331,4 +1331,6 @@ RSpec.describe Spree::Payment, type: :model do
       expect(described_class.valid).to be_empty
     end
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :payment
 end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -237,4 +237,6 @@ RSpec.describe Spree::Refund, type: :model do
       end
     end
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :refund
 end

--- a/core/spec/models/spree/return_authorization_spec.rb
+++ b/core/spec/models/spree/return_authorization_spec.rb
@@ -223,4 +223,6 @@ RSpec.describe Spree::ReturnAuthorization, type: :model do
       it { is_expected.to eq true }
     end
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :return_authorization
 end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -872,4 +872,6 @@ RSpec.describe Spree::Shipment, type: :model do
 
     it { is_expected.to include carton }
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :shipment
 end

--- a/core/spec/models/spree/store_credit_event_spec.rb
+++ b/core/spec/models/spree/store_credit_event_spec.rb
@@ -325,4 +325,6 @@ RSpec.describe Spree::StoreCreditEvent do
       end
     end
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :store_credit_event
 end

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -87,6 +87,8 @@ RSpec.describe Spree::LegacyUser, type: :model do
       end
     end
   end
+
+  it_behaves_like "customer and admin metadata fields: storage and validation", :user
 end
 
 RSpec.describe Spree.user_class, type: :model do

--- a/core/spec/support/shared_examples/metadata.rb
+++ b/core/spec/support/shared_examples/metadata.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "customer and admin metadata fields: storage and validation" do |metadata_class|
+  let(:object) { build(metadata_class) }
+
+  it "responds to customer_metadata" do
+    expect(object).to respond_to(:customer_metadata)
+  end
+
+  it "responds to admin_metadata" do
+    expect(object).to respond_to(:admin_metadata)
+  end
+
+  it "can store data in customer_metadata" do
+    object.customer_metadata = { "order_id" => "OD34236" }
+    expect(object.customer_metadata["order_id"]).to eq("OD34236")
+  end
+
+  it "can store data in admin_metadata" do
+    object.admin_metadata = { "internal_note" => "Generate invoice after payment is received" }
+    expect(object.admin_metadata["internal_note"]).to eq("Generate invoice after payment is received")
+  end
+
+  let(:invalid_metadata_keys) do
+    {
+      "company_name" => "demo company",
+      "warehouse_name" => "warehouse",
+      "serial_number" => "SN-4567890",
+      "manufactured_at" => "head office",
+      "under_warranty" => "true",
+      "delivered_by" => "FedEx",
+      "product_type" => "fragile" # Exceeds 6 keys
+    }
+  end
+
+  let(:valid_metadata_keys) do
+    {
+      "company_name" => "demo company",
+      "warehouse_name" => "warehouse",
+      "serial_number" => "SN-4567890",
+      "manufactured_at" => "head office",
+      "under_warranty" => "true",
+      "delivered_by" => "FedEx"
+    }
+  end
+
+  let(:oversized_value_metadata) { { "product_details" => "This is an amazing product built to last long" * 10 } } # Exceeds 256 characters
+  let(:valid_value_metadata) { { "product_details" => "This is an amazing product built to last long" } }
+  let(:oversized_key_metadata) { { "company_details_for_products" => 'This is made by demo company' } } #  Exceeds 16 characters
+  let(:valid_key_metadata) { { "company_details" => 'This is made by demo company' } }
+
+  subject { create(metadata_class) }
+
+  %w[customer_metadata admin_metadata].each do |metadata_type|
+    describe metadata_type do
+      it "does not allow more than 6 keys" do
+        subject.send("#{metadata_type}=", invalid_metadata_keys)
+
+        expect(subject).not_to be_valid
+        expect(subject.errors[metadata_type.to_sym]).to include("must not have more than 6 keys")
+      end
+
+      it "allows less than 6 keys" do
+        subject.send("#{metadata_type}=", valid_metadata_keys)
+
+        expect(subject).to be_valid
+      end
+
+      it "does not allow values longer than 256 characters" do
+        subject.send("#{metadata_type}=", oversized_value_metadata)
+
+        expect(subject).not_to be_valid
+        expect(subject.errors[metadata_type.to_sym]).to include("value for key 'product_details' exceeds 256 characters")
+      end
+
+      it "allows values shorter than 256 characters" do
+        subject.send("#{metadata_type}=", valid_value_metadata)
+
+        expect(subject).to be_valid
+      end
+
+      it "does not allow keys longer than 16 characters" do
+        subject.send("#{metadata_type}=", oversized_key_metadata)
+
+        expect(subject).not_to be_valid
+        expect(subject.errors[metadata_type.to_sym]).to include("key 'company_details_for_products' exceeds 16 characters")
+      end
+
+      it "allows keys shorter than 16 characters" do
+        subject.send("#{metadata_type}=", valid_key_metadata)
+
+        expect(subject).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #5897
Concerns #5951

# Breaking Changes
This feature breaks sqlite versions predating to [December 2023](https://sqlite.org/jsonb.html), verify your requirements before migrating. 

# Introduction 

## Overview
This PR introduces the concept of metadata fields to solidus. The purpose of metadata fields is to allow customers and admins alike to provide additional information to transactions to either extend the informations contained or allow to insert additional data to correlate transactions with third party systems. 

Examples for data can be: 

- any transaction itself such as orders, RMAs, payments and stock movements;
- individual items contained inside an order (line items);
- match users with 3rd party systems.

Possible Applications on a very high level are:

- customers that want to add Purchase Order information to an order; 
- administrators that want to add a ticket number to an RMA.

The current scope of meta data are following ressources:  
- Users
- Orders
- Customer Returns and any from of correlated transactions
- Payments
- Shipments
- Line Items

## How is the additional information stored?
for each of the above resources two columns have been created:
- customer_metadata
- admin_metadata

The resources store the information as jsonb.

## What is the access model?
Cancancan has been used to allow users to write data with the current scope just extended by the additional fields:
- Users can create / delete / alter metadata on orders only till the payment itself is processed,
- Admins have universal access R/W access to metadata at all stages of transactions.

## Testing
Extensive test cases have been added. 

# Detailed Overview 

## Types of Meta Data and usage suggestions

### Overview 
Meta data can be broken down in three large topics visible in the table below:

|                         | Use Case                                                                                                                                                              |
|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Administrative Metadata | Information required to correlate all transactions to 3rd party systems.                                                                                              |
| Customer Metadata       | Information allowing customers to customize orders (eg options to store information like a text string or link to an image) or correlate transactions (such as POs).  |

### Administrative Metadata
Transactional resources are either by nature integrated with 3rd party systems (eg Payments, Billing in Italy with eInvoicing) or by operational requirement (ERP, CRMs like Salesforce,...). Meta data as an extension on admin site for all transactional resources to connect the transactional resources to any of such systems. Given that more and more countries will switch to a form of eInvoicing in the coming years meta data allows to fetch or store additional information in those transactions.

### Customer Meta Data 
Customer meta data allows users to customize a cart with either administrative (PO numbers,...) or customisation information (eg an URL to a picture to customize a shirt, text strings for incisions or in our case IMEIs to relate to a subscription) allowing to significantly extend the features without changing the underlying model. Fields should be accessible on front-end and backend. 

## Schema 
Meta Data should net a reliable outcome: 
"key1" : "value1" should be as applicable as "key2" : "value2", without restriction other than the quantity of storable key value pairs and limitations of the dimension of the value given that json as a format does not pose limits we should do that server side. 

Future models to reserve or block certain key names might be possible. 

## Scopes & Arrays

### Nature of the Values
The system is agnostic to the value contained. A decision has been made to store the data in additional columns in a jsonb which by now is relatively widely supported. Some preexisting installations might have to upgrade DBs, older sqlite versions dating before Jan 2024 are therefor not supported and need to be updated.

"key1" : "value1" should lead to the same behaviour as "key2" : "value2" without requiring modification inside the code. Reasonable provisions should be taken inside the code base to edit the quantities and content size of key value pairs and appropriate errors should be returned where rate or size limits are exceeded. 

## Administrative Meta Data
Allow appropriate roles to customize resources with private fields not end-user accessible. 
R/W = Read and Write Access
|               | Admin   | Use Case                                                                                                                                  |
|---------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------|
| **Order**     | **R/W** | **Add 3rd party system reference fields such as PO-Order or Dropshipping reference**                                                      |
| **Line Item** | **R/W** | **Add information to customize object such as link to an image for customization of a product or relate to a 3rd party system reference** |
| **RMA**       | **R/W** | **Add 3rd party system reference fields such as PO-Order or Dropshipping reference**                                                      |
| **Payment**   | **R/W** | **Add 3rd party system reference fields such as PO-Order or Dropshipping reference**                                                      |
| **Order**     | **R/W** | **Add 3rd party system reference fields such as PO-Order or Dropshipping reference**                                                      |
| Shipment      | R/W     | Add 3rd party system reference fields such as a delivery note                                                                             |
| Payment       | R/W     | Add 3rd party system reference fields for payment conciliation                                                                            |
| User       | R/W     | Add a 3rd party reference |

## Customer Meta Data 

Allowing users to customize an incomplete order (or I'd say a cart) and call the information after a completed order. Admins should in an ideal case be allowed to edit those information after purchase, but I feel that can wait if technical limitations are currently in place. 

|               | User    | Admin   |    Use Case                                                                                                                                       |
|---------------|---------|---------|-------------------------------------------------------------------------------------------------------------------------------------------|
| **Order**     | **R/W** | **R/W** | **Add 3rd party system reference fields such as PO-Order,**                                                                               |
| **Line Item** | **R/W** | **R/W** | **Add information to customize object such as link to an image for customization of a product or relate to a 3rd party system reference** |
| User          | R/W     | R/W     | Add additional User Fields or References                                                                                                  |