### PR TITLE
Add permalink history for taxon on friendly-id

### DIFF
--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -269,4 +269,28 @@ RSpec.describe Spree::Taxon, type: :model do
       end
     end
   end
+
+  context 'stores history of permalinks' do
+    let(:taxonomy) { create(:taxonomy, name: 'brands') }
+    let(:root) { taxonomy.root }
+    let(:taxon_name) { "ruby on rails" }
+    let(:new_permalink) { "rails for ruby" }
+    let(:expected_initial_slug) { "brands/ruby-on-rails" }
+    let(:expected_updated_slug) { "brands/rails-for-ruby" }
+
+    let!(:taxon) { create(:taxon, name: taxon_name, parent: root) }
+
+    it 'should store the previous slug when permalink is updated' do
+      expect(taxon.slugs.count).to eq(1)
+      expect(expected_initial_slug).to eq(taxon.slugs.last.slug)
+
+      taxon.update(permalink: new_permalink)
+
+      expect(expected_updated_slug).to eq(taxon.permalink)
+      expect(taxon.slugs.count).to eq(2)
+
+      expect(taxon.slugs.pluck(:slug)).to include(expected_initial_slug)
+      expect(taxon.slugs.pluck(:slug)).to include(expected_updated_slug)
+    end
+  end
 end


### PR DESCRIPTION
# [WIP] Open Questions 

This PR aligns URL handling of taxons with products.

Open questions: 
- [ ] The slugs of taxons are currently called permalinks (which they aren't), should they be renamed to slug (in backend and DB) creating also a migration

# Related Issues, PRs and Discussions

- https://github.com/solidusio/solidus/issues/6093
- https://github.com/solidusio/solidus_starter_frontend/pull/415

### Description

This PR introduces `FriendlyId` to the `Taxon` model to store the history of permalinks (slugs) and provides a more flexible approach to handling slugs for taxons.

#### Changes:
- **Taxon Model**:
  - Added `FriendlyId` to the `Taxon` model, enabling it to generate and store slug history.
  - The `before_save` callback is used to set the permalink instead of `before_create` and `before_update`, allowing for better slug management.
  - Introduced a custom method for `should_generate_new_friendly_id?` to control when a new friendly ID should be generated, specifically when the permalink changes.
  - Added a custom `normalize_friendly_id` method to adjust how slugs are generated, especially for nested taxons, ensuring proper formatting of the slug.

- **Test**:
  - Added a test to ensure that the history of permalinks is correctly stored when a taxon's permalink is updated. The test verifies that both the initial and updated slugs are retained in the history.

### Motivation
This update enhances the management of taxon slugs by allowing historical tracking of slugs. This is particularly useful for SEO purposes and for maintaining accessibility of the resource if URLs change over time.


### Note
The starter frontend PR is dependent for this change [starter frontend PR](https://github.com/gms-electronics/solidus_starter_frontend/pull/2)

