### PR TITLE
Store reverse charge status

### DIFF
--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -127,7 +127,7 @@ module Spree
     preference :store_attributes, :array, default: [
       :id, :name, :url, :meta_description, :meta_keywords, :seo_title,
       :mail_from_address, :default_currency, :code, :default, :available_locales,
-      :bcc_email
+      :bcc_email, :reverse_charge_status
     ]
 
     preference :store_credit_history_attributes, :array, default: [

--- a/api/spec/requests/spree/api/stores_spec.rb
+++ b/api/spec/requests/spree/api/stores_spec.rb
@@ -32,6 +32,7 @@ module Spree::Api
             "meta_description" => nil,
             "meta_keywords" => nil,
             "seo_title" => nil,
+            "reverse_charge_status" => 'disabled',
             "mail_from_address" => "solidus@example.org",
             "bcc_email" => nil,
             "default_currency" => nil,
@@ -46,6 +47,7 @@ module Spree::Api
             "meta_description" => nil,
             "meta_keywords" => nil,
             "seo_title" => nil,
+            "reverse_charge_status" => 'disabled',
             "mail_from_address" => "solidus@example.org",
             "bcc_email" => nil,
             "default_currency" => nil,
@@ -65,6 +67,7 @@ module Spree::Api
           "meta_description" => nil,
           "meta_keywords" => nil,
           "seo_title" => nil,
+          "reverse_charge_status" => 'disabled',
           "mail_from_address" => "solidus@example.org",
           "bcc_email" => nil,
           "default_currency" => nil,
@@ -110,6 +113,36 @@ module Spree::Api
         it "will destroy the store" do
           delete spree.api_store_path(non_default_store)
           expect(response.status).to eq(204)
+        end
+      end
+
+      context "reverse_charge_status attribute" do
+        it "can create a new store with reverse_charge_status" do
+          store_hash = {
+            code: "spree123",
+            name: "Hack0rz",
+            url: "spree123.example.com",
+            mail_from_address: "me@example.com",
+            reverse_charge_status: "enabled"
+          }
+          post spree.api_stores_path, params: { store: store_hash }
+          expect(response.status).to eq(201)
+          expect(json_response["reverse_charge_status"]).to eq('enabled')
+        end
+
+        it "can update an existing store with reverse_charge_status" do
+          store_hash = {
+            url: "spree123.example.com",
+            mail_from_address: "me@example.com",
+            bcc_email: "bcc@example.net",
+            reverse_charge_status: "disabled"
+          }
+          put spree.api_store_path(store), params: { store: store_hash }
+          expect(response.status).to eq(200)
+          expect(store.reload.url).to eql "spree123.example.com"
+          expect(store.reload.mail_from_address).to eql "me@example.com"
+          expect(store.reload.bcc_email).to eql "bcc@example.net"
+          expect(store.reload.reverse_charge_status).to eql "disabled"
         end
       end
     end

--- a/backend/app/views/spree/admin/stores/_form.html.erb
+++ b/backend/app/views/spree/admin/stores/_form.html.erb
@@ -30,6 +30,17 @@
       <%= f.text_area :meta_description, class: 'fullwidth' %>
       <%= f.error_message_on :meta_description %>
     <% end %>
+
+    <% if Spree::Backend::Config.show_reverse_charge_fields %>
+      <%= f.field_container :reverse_charge_status do %>
+        <%= f.label :reverse_charge_status %>
+        <%= f.select :reverse_charge_status,
+          Spree::Store.reverse_charge_statuses.keys.map { |key| [I18n.t("spree.reverse_charge_statuses.#{key}"), key] },
+          { include_blank: false },
+          { class: 'custom-select fullwidth' } %>
+        <%= f.error_message_on :reverse_charge_status %>
+      <% end %>
+    <% end %>
   </div>
   <div class="col-12 col-md-6">
     <%= f.field_container :url do %>

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -19,6 +19,10 @@ module Spree
       solidus_admin: 'spree/backend/themes/solidus_admin'
     }
 
+    # @!attribute [rw] show_reverse_charge_fields
+    #   @return [Boolean] Request reverse charge fields. (default: +false+)
+    preference :show_reverse_charge_fields, :boolean, default: false
+
     preference :search_fields, :hash, default: {
       "spree/admin/orders" => [
         {

--- a/core/app/models/spree/store.rb
+++ b/core/app/models/spree/store.rb
@@ -27,6 +27,12 @@ module Spree
     before_save :ensure_default_exists_and_is_unique
     before_destroy :validate_not_default
 
+    enum :reverse_charge_status, {
+      disabled: 0,
+      enabled: 1,
+      not_validated: 2
+    }, prefix: true
+
     def available_locales
       locales = super()
       if locales

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -2081,6 +2081,10 @@ en:
     return_quantity: Return Quantity
     return_reasons: Return Reasons
     returned: Returned
+    reverse_charge_statuses:
+      disabled: Disabled
+      enabled: Enabled
+      not_validated: Not Validated
     review: Review
     risk: Risk
     risk_analysis: Risk Analysis

--- a/core/db/migrate/20250214094207_add_reverse_charge_status_to_store.rb
+++ b/core/db/migrate/20250214094207_add_reverse_charge_status_to_store.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddReverseChargeStatusToStore < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_stores, :reverse_charge_status, :integer, default: 0, null: false,
+                comment: "Enum values: 0 = disabled, 1 = enabled, 2 = not_validated"
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -113,7 +113,7 @@ module Spree
     @@store_attributes = [:name, :url, :seo_title, :meta_keywords,
                           :meta_description, :default_currency,
                           :mail_from_address, :cart_tax_country_iso,
-                          :bcc_email]
+                          :bcc_email, :reverse_charge_status]
 
     @@taxonomy_attributes = [:name]
 

--- a/core/spec/models/spree/store_spec.rb
+++ b/core/spec/models/spree/store_spec.rb
@@ -106,4 +106,34 @@ RSpec.describe Spree::Store, type: :model do
       end
     end
   end
+
+  describe 'enum reverse_charge_status' do
+    it 'defines the expected enum values' do
+      expect(Spree::Store.reverse_charge_statuses).to eq({
+        'disabled' => 0,
+        'enabled' => 1,
+        'not_validated' => 2
+      })
+    end
+
+    it 'allows valid values' do
+      store = build(:store)
+      # Updates the reverse_charge_status to "not_validated"
+      expect(store).to be_valid
+      store.reverse_charge_status_not_validated!
+
+      # Updates the reverse_charge_status to "disabled"
+      expect(store).to be_valid
+      store.reverse_charge_status_disabled!
+      expect(store).to be_valid
+
+      # Updates the reverse_charge_status to "enabled"
+      store.reverse_charge_status_enabled!
+      expect(store).to be_valid
+    end
+
+    it 'raises an error for invalid values' do
+      expect { Spree::Store.new(reverse_charge_status: :invalid_status) }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION

**Description:**
This PR introduces the `reverse_charge_status` functionality to the Store model, allowing users to manage and select the reverse charge status for each store. The changes include:

1. **Store Model Update:**
   - Introduced a new enum `reverse_charge_status` to the `Store` model.
   - This enum allows the store's reverse charge status to be set to one of the following values:
     - `enabled`
     - `disabled`
     - `not validated`

2. **API Support:**
   - API endpoints for store management have been updated to support the newly added `reverse_charge_status`.
   - The attribute can now be accessed and modified through existing store APIs.

3. **Admin Form Update:**
   - The store admin form has been updated to include a dropdown for selecting the reverse charge status.
   - Users can now easily select the desired charge status when managing a store.

![New-Store-Stores-02-14-2025_06_53_PM](https://github.com/user-attachments/assets/5d71c6da-d34f-4cdf-a6bc-5552412e6d40)
