### PR TITLE
Restore firstname lastname on address

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/address/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/forms/address/component.html.erb
@@ -4,6 +4,11 @@
 >
   <div class="<%= stimulus_id %>--address-form flex flex-wrap gap-4 pb-4">
     <%= render component("ui/forms/field").text_field(@name, :name, object: @address) %>
+    <%= render component("ui/forms/field").text_field(@name, :firstname, object: @address) %>
+    <%= render component("ui/forms/field").text_field(@name, :lastname, object: @address) %>
+    <% if Spree::Config[:company] %>
+      <%= render component("ui/forms/field").text_field(@name, :company, object: @address) %>
+    <% end %>
     <%= render component("ui/forms/field").text_field(@name, :address1, object: @address) %>
     <%= render component("ui/forms/field").text_field(@name, :address2, object: @address) %>
     <div class="flex gap-4 w-full">

--- a/admin/spec/features/orders/show_spec.rb
+++ b/admin/spec/features/orders/show_spec.rb
@@ -52,6 +52,8 @@ describe "Order", :js, type: :feature do
 
     within("dialog") do
       fill_in "Name", with: "John Doe"
+      fill_in "First Name", with: "John"
+      fill_in "Last Name", with: "Doe"
       fill_in "Street Address", with: "1 John Doe Street"
       fill_in "Street Address (cont'd)", with: "Apartment 2"
       fill_in "City", with: "John Doe City"
@@ -78,6 +80,8 @@ describe "Order", :js, type: :feature do
 
     within("dialog") do
       fill_in "Name", with: "Jane Doe"
+      fill_in "First Name", with: "Jane"
+      fill_in "Last Name", with:  "Doe"
       fill_in "Street Address", with: "1 Jane Doe Street"
       fill_in "Street Address (cont'd)", with: "Apartment 3"
       fill_in "City", with: "Jane Doe City"

--- a/admin/spec/features/users_spec.rb
+++ b/admin/spec/features/users_spec.rb
@@ -129,14 +129,16 @@ describe "Users", :js, type: :feature do
       # Invalid submission
       within("form.ship_address") do
         fill_in "Name", with: ""
+        fill_in "First Name", with: ""
         fill_in "Street Address", with: ""
         click_on "Update"
       end
-      expect(page).to have_content("can't be blank").twice
+      expect(page).to have_content("can't be blank").thrice
 
       # Valid submission
       within("form.bill_address") do
         fill_in "Name", with: "Galadriel"
+        fill_in "First Name", with: "Galadriel"
         click_on "Update"
       end
       expect(page).to have_content("Billing Address has been successfully updated.")
@@ -144,6 +146,7 @@ describe "Users", :js, type: :feature do
       # Valid submission
       within("form.ship_address") do
         fill_in "Name", with: "Elrond"
+        fill_in "First Name", with: "Elrond"
         click_on "Update"
       end
       expect(page).to have_content("Shipping Address has been successfully updated.")
@@ -151,6 +154,7 @@ describe "Users", :js, type: :feature do
       # Cancel submission
       within("form.bill_address") do
         fill_in "Name", with: "Smeagol"
+        fill_in "First Name", with: "Smeagol"
         click_on "Cancel"
       end
       expect(page).to have_content("Users / customer@example.com / Addresses")
@@ -159,6 +163,8 @@ describe "Users", :js, type: :feature do
       # The address forms weirdly only have values rather than actual text on the page.
       expect(page).to have_field("user[bill_address_attributes][name]", with: "Galadriel")
       expect(page).to have_field("user[ship_address_attributes][name]", with: "Elrond")
+      expect(page).to have_field("user[bill_address_attributes][firstname]", with: "Galadriel")
+      expect(page).to have_field("user[ship_address_attributes][firstname]", with: "Elrond")
     end
   end
 

--- a/admin/spec/requests/solidus_admin/users_spec.rb
+++ b/admin/spec/requests/solidus_admin/users_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "SolidusAdmin::UsersController", type: :request do
       user: {
         bill_address_attributes: {
           name: address.name,
+          firstname: address.firstname,
+          lastname: address.lastname,
           address1: address.address1,
           address2: address.address2,
           city: address.city,

--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -61,7 +61,7 @@ module Spree
     ]
 
     preference :address_attributes, :array, default: [
-      :id, :name, :address1, :address2, :city, :zipcode, :phone, :company,
+      :id, :name, :firstname, :lastname, :address1, :address2, :city, :zipcode, :phone, :company,
       :alternative_phone, :country_id, :country_iso, :state_id, :state_name,
       :state_text
     ]

--- a/api/spec/requests/spree/api/address_books_spec.rb
+++ b/api/spec/requests/spree/api/address_books_spec.rb
@@ -8,6 +8,8 @@ module Spree::Api
     let!(:harry_address_attributes) do
       {
         'name' => 'Harry Potter',
+        'firstname' => 'Harry',
+        'lastname' => 'Potter',
         'address1' => '4 Privet Drive',
         'address2' => 'cupboard under the stairs',
         'city' => 'Surrey',
@@ -21,6 +23,8 @@ module Spree::Api
     let!(:ron_address_attributes) do
       {
         'name' => 'Ron Weasly',
+        'firstname' => 'Ron',
+        'lastname' => 'Weasly',
         'address1' => 'Ottery St. Catchpole',
         'address2' => '4th floor',
         'city' => 'Devon, West Country',
@@ -54,6 +58,8 @@ module Spree::Api
           user = create(:user, spree_api_key: 'galleon')
           address = user.save_in_address_book(harry_address_attributes, true)
           harry_address_attributes['name'] = 'Ron Weasly'
+          harry_address_attributes['firstname'] = 'Ron'
+          harry_address_attributes['lastname'] = 'Weasly'
 
           expect {
             put "/api/users/#{user.id}/address_book",
@@ -73,7 +79,7 @@ module Spree::Api
 
         context "when updating a default address" do
           let(:user) { create(:user, spree_api_key: 'galleon') }
-          let(:changes) { { name: "Hermione Granger", id: user.ship_address.id} }
+          let(:changes) { { name: "Hermione Granger", firstname: "Hermione", lastname: "Granger", id: user.ship_address.id} }
           before do
             # Create "Harry Potter" default shipping address
             user.save_in_address_book(harry_address_attributes, true)
@@ -168,7 +174,9 @@ module Spree::Api
         it "updates another user's address" do
           other_user = create(:user)
           address = other_user.save_in_address_book(harry_address_attributes, true)
-          updated_harry_address = harry_address_attributes.merge('name' => 'Ron Weasly')
+          harry_address_attributes.merge('firstname' => 'Ron')
+          harry_address_attributes.merge('name' => 'Ron Weasly')
+          updated_harry_address = harry_address_attributes.merge('lastname' => 'Weasly')
 
           expect {
             put "/api/users/#{other_user.id}/address_book",

--- a/api/spec/requests/spree/api/checkouts_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_spec.rb
@@ -72,6 +72,8 @@ module Spree::Api
         let(:address) do
           {
             name:  'John Doe',
+            firstname:  'John',
+            lastname:   'Doe',
             address1:   '7735 Old Georgetown Road',
             city:       'Bethesda',
             phone:      '3014445002',
@@ -96,6 +98,8 @@ module Spree::Api
           expect(json_response['state']).to eq('delivery')
           expect(json_response['bill_address']['name']).to eq('John Doe')
           expect(json_response['ship_address']['name']).to eq('John Doe')
+          expect(json_response['bill_address']['firstname']).to eq('John')
+          expect(json_response['ship_address']['firstname']).to eq('John')
           expect(response.status).to eq(200)
         end
 

--- a/api/spec/requests/spree/api/orders_spec.rb
+++ b/api/spec/requests/spree/api/orders_spec.rb
@@ -531,12 +531,12 @@ module Spree::Api
 
       let(:address_params) { { country_id: country.id } }
       let(:billing_address) {
-        { name: "Tiago Motta", address1: "Av Paulista",
+        { name: "Tiago Motta", firstname: "Tiago", lastname: "Motta", address1: "Av Paulista",
                                 city: "Sao Paulo", zipcode: "01310-300", phone: "12345678",
                                 country_id: country.id, state_id: state.id }
       }
       let(:shipping_address) {
-        { name: "Tiago Motta", address1: "Av Paulista",
+        { name: "Tiago Motta", firstname: "Tiago", lastname: "Motta", address1: "Av Paulista",
                                  city: "Sao Paulo", zipcode: "01310-300", phone: "12345678",
                                  country_id: country.id, state_id: state.id }
       }

--- a/api/spec/requests/spree/api/users_spec.rb
+++ b/api/spec/requests/spree/api/users_spec.rb
@@ -51,6 +51,8 @@ module Spree::Api
           email: "mine@example.com",
           bill_address_attributes: {
             name: 'First Last',
+            firstname: 'First',
+            lastname: 'Last',
             address1: '1 Test Rd',
             city: 'City',
             country_id: country.id,
@@ -60,6 +62,8 @@ module Spree::Api
           },
           ship_address_attributes: {
             name: 'First Last',
+            firstname: 'First',
+            lastname: 'Last',
             address1: '1 Test Rd',
             city: 'City',
             country_id: country.id,
@@ -84,6 +88,8 @@ module Spree::Api
             email: "mine@example.com",
             bill_address_attributes: {
               name: 'First Last',
+              firstname: 'First',
+              lastname: 'Last',
               address1: '1 Test Rd',
               city: 'City',
               country_id: country.id,
@@ -93,6 +99,8 @@ module Spree::Api
             },
             ship_address_attributes: {
               name: 'First Last',
+              firstname: 'First',
+              lastname: 'Last',
               address1: '1 Test Rd',
               city: 'City',
               country_id: country.id,

--- a/backend/app/assets/javascripts/spree/backend/templates/orders/customer_details/autocomplete.hbs
+++ b/backend/app/assets/javascripts/spree/backend/templates/orders/customer_details/autocomplete.hbs
@@ -4,6 +4,7 @@
     {{#if bill_address.name }}
       <strong>{{t 'bill_address' }}</strong>
       {{bill_address.name}}<br>
+      {{bill_address.firstname}} {{bill_address.lastname}}<br>
       {{bill_address.address1}}, {{bill_address.address2}}<br>
       {{bill_address.city}}<br>
       {{#if bill_address.state_id }}

--- a/backend/app/assets/javascripts/spree/backend/user_picker.js
+++ b/backend/app/assets/javascripts/spree/backend/user_picker.js
@@ -28,7 +28,9 @@ $.fn.userAutocomplete = function () {
           q: {
             m: 'or',
             email_start: term,
-            name_start: term
+            name_start: term,
+            firstname_start: term,
+            lastname_start: term
           }
         };
       },

--- a/backend/app/assets/javascripts/spree/backend/views/order/address.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/address.js
@@ -23,7 +23,7 @@ Spree.Views.Order.Address = Backbone.View.extend({
 
   eachField: function(callback){
     var view = this;
-    var fields = ["name", "company", "address1", "address2",
+    var fields = ["name", "firstname", "lastname", "company", "address1", "address2",
       "city", "zipcode", "phone", "country_id", "state_name"];
     _.each(fields, function(field) {
       var el = view.$('[name$="[' + field + ']"]');

--- a/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/customer_select.js
@@ -34,7 +34,9 @@ Spree.Views.Order.CustomerSelect = Backbone.View.extend({
             q: {
               m: 'or',
               email_start: term,
-              name_start: term
+              name_start: term,
+              firstname_start: term,
+              lastname_start: term
             }
           }
         },

--- a/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_orders.scss
@@ -65,7 +65,7 @@
 }
 
 label[for="order_bill_address_attributes_name"] {
-  margin-top: 53.5px;
+  margin-top: 45px;
 }
 
 #risk_analysis legend {

--- a/backend/app/controllers/spree/admin/search_controller.rb
+++ b/backend/app/controllers/spree/admin/search_controller.rb
@@ -16,7 +16,9 @@ module Spree
           @users = Spree.user_class.ransack({
             m: 'or',
             email_start: params[:q],
-            name_start: params[:q]
+            name_start: params[:q],
+            addresses_firstname_start: params[:q],
+            addresses_lastname_start: params[:q]
           }).result.limit(10)
         end
       end

--- a/backend/app/views/spree/admin/search/users.json.jbuilder
+++ b/backend/app/views/spree/admin/search/users.json.jbuilder
@@ -6,6 +6,8 @@ json.array!(@users) do |user|
 
   address_fields = [
     :name,
+    :firstname,
+    :lastname,
     :address1,
     :address2,
     :city,

--- a/backend/app/views/spree/admin/shared/_address.html.erb
+++ b/backend/app/views/spree/admin/shared/_address.html.erb
@@ -1,5 +1,5 @@
 <div data-hook="address">
-  <%= address.name %> <%= address.company unless address.company.blank? %><br>
+  <%= address.name %> <%= "#{address.firstname} #{address.lastname} " %> <%= address.company unless address.company.blank? %><br>
   <%= address.phone %><%= address.alternative_phone unless address.alternative_phone.blank? %><br>
   <%= address.address1 %><br>
   <% if address.address2.present? %><%= address.address2 %><br><% end %>

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -6,6 +6,16 @@
     <%= f.text_field :name, class: 'fullwidth' %>
   </div>
 
+  <div class="field <%= "#{type}-row" %>">
+    <%= f.label :firstname %>
+    <%= f.text_field :firstname, class: 'fullwidth' %>
+  </div>
+
+  <div class="field <%= "#{type}-row" %>">
+    <%= f.label :lastname %>
+    <%= f.text_field :lastname, class: 'fullwidth' %>
+  </div>
+
   <% if Spree::Config[:company] %>
     <div class="field <%= "#{type}-row" %>">
       <%= f.label :company %>

--- a/backend/lib/spree/backend_configuration.rb
+++ b/backend/lib/spree/backend_configuration.rb
@@ -72,7 +72,7 @@ module Spree
         {
           partial: "spree/admin/shared/search_fields/text_field",
           locals: {
-            ransack: :bill_address_name_cont,
+            ransack: :bill_address_firstname_or_bill_address_lastname_cont,
             label: -> { I18n.t(:name_contains, scope: :spree) }
           }
         },

--- a/backend/spec/controllers/spree/admin/payments_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/payments_controller_spec.rb
@@ -56,6 +56,7 @@ module Spree
             let(:address_attributes) do
               {
                 'name' => address.name,
+                'firstname' => address.firstname,
                 'address1' => address.address1,
                 'city' => address.city,
                 'country_id' => address.country_id,

--- a/backend/spec/controllers/spree/admin/search_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/search_controller_spec.rb
@@ -37,7 +37,7 @@ describe Spree::Admin::SearchController, type: :controller do
         end
       end
 
-      context 'when searching by ship addresss name' do
+      context 'when searching by ship address name' do
         it_should_behave_like 'user found by search' do
           let(:search_query) { starting_letters(user.ship_address.name) }
         end
@@ -46,6 +46,30 @@ describe Spree::Admin::SearchController, type: :controller do
       context 'when searching by bill address name' do
         it_should_behave_like 'user found by search' do
           let(:search_query) { starting_letters(user.bill_address.name) }
+        end
+      end
+
+      context 'when searching by ship address first name' do
+        it_should_behave_like 'user found by search' do
+          let(:search_query) { starting_letters(user.ship_address.firstname) }
+        end
+      end
+
+      context 'when searching by bill address first name' do
+        it_should_behave_like 'user found by search' do
+          let(:search_query) { starting_letters(user.bill_address.firstname) }
+        end
+      end
+
+      context 'when searching by ship address last name' do
+        it_should_behave_like 'user found by search' do
+          let(:search_query) { starting_letters(user.ship_address.lastname) }
+        end
+      end
+
+      context 'when searching by bill address last name' do
+        it_should_behave_like 'user found by search' do
+          let(:search_query) { starting_letters(user.bill_address.lastname) }
         end
       end
     end

--- a/backend/spec/controllers/spree/admin/users_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/users_controller_spec.rb
@@ -9,6 +9,8 @@ describe Spree::Admin::UsersController, type: :controller do
   let(:valid_address_attributes) do
     {
       name: 'Foo Bar',
+      firstname: 'Foo',
+      lastname: 'Bar',
       city: "New York",
       country_id: state.country.id,
       state_id: state.id,

--- a/backend/spec/features/admin/orders/customer_details_spec.rb
+++ b/backend/spec/features/admin/orders/customer_details_spec.rb
@@ -14,8 +14,8 @@ describe "Customer Details", type: :feature, js: true do
   let!(:product) { create(:product_in_stock) }
 
   # We need a unique name that will appear for the customer dropdown
-  let!(:ship_address) { create(:address, country:, state:, name: "Jane Doe") }
-  let!(:bill_address) { create(:address, country:, state:, name: "Jane Doe") }
+  let!(:ship_address) { create(:address, country:, state:, firstname: "Jane", lastname: "Doe", name: "Jane Doe") }
+  let!(:bill_address) { create(:address, country:, state:, firstname: "Jane", lastname: "Doe", name: "Jane Doe") }
 
   let!(:user) { create(:user, email: 'foobar@example.com', ship_address:, bill_address:) }
 
@@ -38,6 +38,8 @@ describe "Customer Details", type: :feature, js: true do
     it "associates a user when not using guest checkout" do
       # 5317 - Address prefills using user's default.
       expect(page).to have_field('Name', with: user.bill_address.name)
+      expect(page).to have_field('First Name', with: user.bill_address.firstname)
+      expect(page).to have_field('Last Name', with: user.bill_address.lastname)
       expect(page).to have_field('Street Address', with: user.bill_address.address1)
       expect(page).to have_field("Street Address (cont'd)", with: user.bill_address.address2)
       expect(page).to have_field('City', with: user.bill_address.city)
@@ -120,6 +122,7 @@ describe "Customer Details", type: :feature, js: true do
       click_link "Customer"
       click_button "Update"
       expect(page).to have_content("Shipping address name can't be blank")
+      expect(page).to have_content("Shipping address first name can't be blank")
     end
 
     context "for an order in confirm state with a user" do
@@ -171,6 +174,8 @@ describe "Customer Details", type: :feature, js: true do
         click_link "Customer"
         # Need to fill in valid information so it passes validations
         fill_in "order_ship_address_attributes_name",       with: "John 99 Doe"
+        fill_in "order_ship_address_attributes_firstname",  with: "John 99"
+        fill_in "order_ship_address_attributes_lastname",   with: "Doe"
         fill_in "order_ship_address_attributes_company",    with: "Company"
         fill_in "order_ship_address_attributes_address1",   with: "100 first lane"
         fill_in "order_ship_address_attributes_address2",   with: "#101"
@@ -189,6 +194,8 @@ describe "Customer Details", type: :feature, js: true do
 
   def fill_in_address
     fill_in "Name",                    with: "John 99 Doe"
+    fill_in "First Name",              with: "John 99"
+    fill_in "Last Name",               with: "Doe"
     fill_in "Company",                 with: "Company"
     fill_in "Street Address",          with: "100 first lane"
     fill_in "Street Address (cont'd)", with: "#101"

--- a/backend/spec/features/admin/orders/new_order_spec.rb
+++ b/backend/spec/features/admin/orders/new_order_spec.rb
@@ -368,6 +368,8 @@ describe "New Order", type: :feature do
 
   def fill_in_address
     fill_in "Name",                      with: "John 99 Doe"
+    fill_in "First Name",                with: "John 99"
+    fill_in "Last Name",                 with: "Doe"
     fill_in "Street Address",            with: "100 first lane"
     fill_in "Street Address (cont'd)",   with: "#101"
     fill_in "City",                      with: "Bethesda"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
         address2: Street Address (cont'd)
         city: City
         company: Company
+        firstname: First Name
+        lastname: Last Name
         name: Name
         phone: Phone
         zipcode: Zip Code
@@ -127,6 +129,8 @@ en:
       spree/order/bill_address:
         address1: Billing address street
         city: Billing address city
+        firstname: Billing address first name
+        lastname: Billing address last name
         name: Billing address name
         phone: Billing address phone
         state: Billing address state
@@ -134,6 +138,8 @@ en:
       spree/order/ship_address:
         address1: Shipping address street
         city: Shipping address city
+        firstname: Shipping address first name
+        lastname: Shipping address last name
         name: Shipping address name
         phone: Shipping address phone
         state: Shipping address state
@@ -1568,6 +1574,7 @@ en:
     first_item: First Item
     first_name: First Name
     first_name_begins_with: First Name Begins With
+    firstname: First Name
     flat_percent: Flat Percent
     flat_rate_per_order: Flat Rate
     flexible_rate: Flexible Rate
@@ -1706,6 +1713,7 @@ en:
       path: Path
     last_name: Last Name
     last_name_begins_with: Last Name Begins With
+    lastname: Last Name
     learn_more: Learn More
     lifetime_stats: Lifetime Stats
     line_item_adjustments: Line item adjustments

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -39,7 +39,7 @@ module Spree
     mattr_reader(*ATTRIBUTES)
 
     @@address_attributes = [
-      :id, :name, :address1, :address2, :city, :country_id, :state_id,
+      :id, :name, :firstname, :lastname, :address1, :address2, :city, :country_id, :state_id,
       :zipcode, :phone, :state_name, :country_iso, :alternative_phone, :company,
       country: [:iso, :name, :iso3, :iso_name],
       state: [:name, :abbr]

--- a/core/lib/spree/testing_support/factories/address_factory.rb
+++ b/core/lib/spree/testing_support/factories/address_factory.rb
@@ -9,6 +9,8 @@ FactoryBot.define do
     end
 
     name { 'John Von Doe' }
+    firstname { 'John' }
+    lastname { 'Von Doe' }
     company { 'Company' }
     address1 { '10 Lovely Street' }
     address2 { 'Northwest' }

--- a/core/spec/lib/spree/core/importer/order_spec.rb
+++ b/core/spec/lib/spree/core/importer/order_spec.rb
@@ -37,6 +37,8 @@ module Spree
         {
          address1: '123 Testable Way',
          name: 'Fox Mulder',
+         firstname: 'Fox',
+         lastname: 'Mulder',
          city: 'Washington',
          country_id: country.id,
          state_id: state.id,

--- a/core/spec/models/spree/concerns/user_address_book_spec.rb
+++ b/core/spec/models/spree/concerns/user_address_book_spec.rb
@@ -134,6 +134,10 @@ module Spree
               expect(subject.city).to eq updated_address_attributes[:city]
             end
 
+            it "preserves firstname" do
+              expect(subject.firstname).to eq address.firstname
+            end
+
             it "preserves name" do
               expect(subject.name).to eq address.name
             end
@@ -158,9 +162,12 @@ module Spree
 
       context "updating an address and making default at once" do
         let(:address1) { create(:address) }
-        let(:address2) { create(:address, name: "Different") }
+        let(:address2) { create(:address, firstname: "Different", name: "Different") }
         let(:updated_attrs) do
-          address2.attributes.tap { |value| value[:name] = "Johnny" }
+          address2.attributes.tap do |value|
+            value[:firstname] = "Johnny"
+            value[:name] = "Johnny"
+          end
         end
 
         before do
@@ -170,6 +177,7 @@ module Spree
 
         it "returns the edit as the first address" do
           user.save_in_address_book(updated_attrs, true)
+          expect(user.user_addresses.first.address.firstname).to eq "Johnny"
           expect(user.user_addresses.first.address.name).to eq "Johnny"
         end
       end
@@ -229,7 +237,7 @@ module Spree
 
     context "#remove_from_address_book" do
       let(:address1) { create(:address) }
-      let(:address2) { create(:address, name: "Different") }
+      let(:address2) { create(:address, firstname: "Different", name: "Different") }
       let(:remove_id) { address1.id }
 
       subject { user.remove_from_address_book(remove_id) }

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -93,6 +93,8 @@ RSpec.describe Spree::CreditCard, type: :model do
     let(:valid_address_attributes) do
       {
         name: "Hugo Furst",
+        firstname: "Hugo",
+        lastname: "Furst",
         address1: "123 Main",
         city: "Somewhere",
         country_id: country.id,

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -1971,8 +1971,8 @@ RSpec.describe Spree::Order, type: :model do
   end
 
   describe "#name" do
-    let(:bill_address) { create(:address, name: "John Doe") }
-    let(:ship_address) { create(:address, name: "Jane Doe") }
+    let(:bill_address) { create(:address, firstname: "John", lastname: "Doe", name: "") }
+    let(:ship_address) { create(:address, firstname: "Jane", lastname: "Doe", name: "") }
 
     let(:order) { create(:order, bill_address:, ship_address:) }
 
@@ -2074,12 +2074,15 @@ RSpec.describe Spree::Order, type: :model do
 
   describe "#bill_address_attributes=" do
     let(:order) { create(:order) }
-    let(:address_attributes) { { name: "Mickey Mouse" } }
+    let(:address_attributes) { { firstname: "Mickey", lastname: "Mouse", name: "Mickey Mouse" } }
 
     subject { order.bill_address_attributes = address_attributes }
 
     it "creates a new bill address" do
-      expect { subject }.to change { order.bill_address.name }.to("Mickey Mouse")
+      subject
+      expect(order.bill_address.firstname).to eq("Mickey")
+      expect(order.bill_address.lastname).to eq("Mouse")
+      expect(order.bill_address.name).to eq("Mickey Mouse")
     end
   end
 

--- a/sample/db/samples/addresses.rb
+++ b/sample/db/samples/addresses.rb
@@ -3,10 +3,12 @@
 united_states = Spree::Country.find_by!(iso: "US")
 new_york = Spree::State.find_by!(name: "New York")
 
-names = ["Sterling Torp", "Jennette Vandervort", "Salome Stroman", "Lyla Lang",
-         "Lola Zulauf", "Cheree Bruen", "Hettie Torp", "Barbie Gutmann",
-         "Amelia Renner", "Marceline Bergstrom", "Keeley Sauer", "Mi Gaylord",
-         "Karon Mills", "Jessika Daugherty", "Emmy Stark"]
+first_names = ["Sterling", "Jennette", "Salome", "Lyla", "Lola", "Cheree",
+               "Hettie", "Barbie", "Amelia", "Marceline", "Keeley", "Mi",
+               "Karon", "Jessika", "Emmy"]
+last_names = ["Torp", "Vandervort", "Stroman", "Lang", "Zulauf", "Bruen",
+              "Torp", "Gutmann", "Renner", "Bergstrom", "Sauer", "Gaylord",
+              "Mills", "Daugherty", "Stark"]
 street_addresses = ["7377 Jacobi Passage", "4725 Serena Ridges",
                     "79832 Hamill Creek", "0746 Genoveva Villages",
                     "86717 D'Amore Hollow", "8529 Delena Well",
@@ -26,7 +28,8 @@ phone_numbers = ["(392)859-7319 x670", "738-831-3210 x6047",
 
 2.times do
   Spree::Address.create!(
-    name: names.sample,
+    firstname: first_names.sample,
+    lastname: last_names.sample,
     address1: street_addresses.sample,
     address2: secondary_addresses.sample,
     city: cities.sample,


### PR DESCRIPTION
#### Description:
This PR introduces updates to the address model, admin components, backend, API, and associated logic to handle `firstname` and `lastname` as separate fields, replacing the previous `name` field providing backwards compatibility to existing implementations of name. The updates aim to improve data handling and increase clarity when working with user and address-related data. 

For the purpose of not breaking `name` and provide a smooth transistion if first and last name are used name is compiled with the concatenated value allowing the fields to coexist. 

#### Changes:
- **Admin**: Updated admin components to use `firstname` and `lastname` fields separately in place of the `name` field.
- **Backend**: Modified backend logic to separate `name` into `firstname` and `lastname`, adjusting user and address forms, search functionality, and related views.
- **API**: Updated the API and its associated tests to manage `firstname` and `lastname` fields separately, replacing the `name` field.
- **Core**: Unignored the `firstname` and `lastname` fields in the address model. Introduced a `set_full_name` method for backward compatibility, concatenating `firstname` and `lastname`. Updated tests, factories, and locales to align with the new model structure.