### PR TITLE
[Compliance] Add fields required for reverse charge to addresses (Admin / API)

### DIFF
--- a/admin/app/components/solidus_admin/ui/forms/address/component.html.erb
+++ b/admin/app/components/solidus_admin/ui/forms/address/component.html.erb
@@ -50,5 +50,15 @@
     <% end %>
 
     <%= render component("ui/forms/field").text_field(@form_field_name, :phone,  object: @addressable) %>
+    <%= render component("ui/forms/field").text_field(@form_field_name, :email,  object: @addressable) %>
+    <% if Spree::Backend::Config.show_reverse_charge_fields %>
+      <%= render component("ui/forms/field").text_field(@form_field_name, :vat_id,  object: @addressable) %>
+      <%= render component("ui/forms/field").select(
+        @form_field_name,
+        :reverse_charge_status,
+        Spree::Address.reverse_charge_statuses.keys.map { |key| [I18n.t("spree.reverse_charge_statuses.#{key}"), key] },
+        object: @addressable
+      ) %>
+    <% end %>
   </div>
 </fieldset>

--- a/api/lib/spree/api_configuration.rb
+++ b/api/lib/spree/api_configuration.rb
@@ -85,7 +85,7 @@ module Spree
     preference :address_attributes, :array, default: [
       :id, :name, :address1, :address2, :city, :zipcode, :phone, :company,
       :alternative_phone, :country_id, :country_iso, :state_id, :state_name,
-      :state_text
+      :state_text, :email, :vat_id, :reverse_charge_status
     ]
 
     preference :country_attributes, :array, default: [:id, :iso_name, :iso, :iso3, :name, :numcode]

--- a/api/spec/requests/spree/api/checkouts_spec.rb
+++ b/api/spec/requests/spree/api/checkouts_spec.rb
@@ -77,7 +77,10 @@ module Spree::Api
             phone:      '3014445002',
             zipcode:    '20814',
             state_id:   @state.id,
-            country_id: @country.id
+            country_id: @country.id,
+            email: 'john@doe.com',
+            vat_id: 'ab1235',
+            reverse_charge_status: 'disabled'
           }
         end
 
@@ -95,7 +98,14 @@ module Spree::Api
             } }
           expect(json_response['state']).to eq('delivery')
           expect(json_response['bill_address']['name']).to eq('John Doe')
+          expect(json_response['bill_address']['email']).to eq('john@doe.com')
+          expect(json_response['bill_address']['vat_id']).to eq('ab1235')
+          expect(json_response['bill_address']['reverse_charge_status']).to eq('disabled')
           expect(json_response['ship_address']['name']).to eq('John Doe')
+          expect(json_response['ship_address']['email']).to eq('john@doe.com')
+          expect(json_response['ship_address']['vat_id']).to eq('ab1235')
+          expect(json_response['ship_address']['reverse_charge_status']).to eq('disabled')
+
           expect(response.status).to eq(200)
         end
 

--- a/backend/app/assets/javascripts/spree/backend/views/order/address.js
+++ b/backend/app/assets/javascripts/spree/backend/views/order/address.js
@@ -24,7 +24,7 @@ Spree.Views.Order.Address = Backbone.View.extend({
   eachField: function(callback){
     var view = this;
     var fields = ["name", "company", "address1", "address2",
-      "city", "zipcode", "phone", "country_id", "state_name"];
+      "city", "zipcode", "phone", "country_id", "state_name", "vat_id", "email", "reverse_charge_status"];
     _.each(fields, function(field) {
       var el = view.$('[name$="[' + field + ']"]');
       if (el.length) callback(field, el);

--- a/backend/app/views/spree/admin/search/users.json.jbuilder
+++ b/backend/app/views/spree/admin/search/users.json.jbuilder
@@ -14,7 +14,10 @@ json.array!(@users) do |user|
     :state_name,
     :state_id,
     :country_id,
-    :company
+    :company,
+    :email,
+    :vat_id,
+    :reverse_charge_status
   ]
   json.ship_address do
     if user.ship_address

--- a/backend/app/views/spree/admin/shared/_address.html.erb
+++ b/backend/app/views/spree/admin/shared/_address.html.erb
@@ -1,6 +1,8 @@
 <div data-hook="address">
   <%= address.name %> <%= address.company unless address.company.blank? %><br>
   <%= address.phone %><%= address.alternative_phone unless address.alternative_phone.blank? %><br>
+  <%= address.email unless address.email.blank? %><br>
+  <%= address.vat_id unless address.vat_id.blank? %><br>
   <%= address.address1 %><br>
   <% if address.address2.present? %><%= address.address2 %><br><% end %>
   <%= "#{address.city}, #{address.state_text}, #{address.zipcode}" %><br>

--- a/backend/app/views/spree/admin/shared/_address_form.html.erb
+++ b/backend/app/views/spree/admin/shared/_address_form.html.erb
@@ -63,4 +63,24 @@
     <%= f.label :phone %>
     <%= f.phone_field :phone, class: 'fullwidth' %>
   </div>
+
+  <div class="field <%= "#{type}-row" %>">
+    <%= f.label :email %>
+    <%= f.email_field :email, class: 'fullwidth' %>
+  </div>
+  
+  <% if Spree::Backend::Config.show_reverse_charge_fields %>
+    <div class="field <%= "#{type}-row" %>">
+      <%= f.label :vat_id %>
+      <%= f.text_field :vat_id, class: 'fullwidth' %>
+    </div>
+
+    <div class="field <%= "#{type}-row" %>">
+      <%= f.label :reverse_charge_status %>
+      <%= f.select :reverse_charge_status,
+          Spree::Address.reverse_charge_statuses.keys.map { |key| [I18n.t("spree.reverse_charge_statuses.#{key}"), key] },
+          { include_blank: false },
+          { class: 'custom-select fullwidth' } %>
+    </div>
+  <% end %>
 </div>

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -28,6 +28,12 @@ module Spree
 
     self.allowed_ransackable_attributes = %w[name]
 
+    enum :reverse_charge_status, {
+      disabled: 0,
+      enabled: 1,
+      not_validated: 2
+    }, prefix: true
+
     unless ActiveRecord::Relation.method_defined? :with_values # Rails 7.1+
       scope :with_values, ->(attributes) do
         where(value_attributes(attributes))

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -24,8 +24,10 @@ en:
         address2: Street Address (cont'd)
         city: City
         company: Company
+        email: Email
         name: Name
         phone: Phone
+        vat_id: VAT-ID
         zipcode: Zip Code
       spree/adjustment:
         adjustable: Adjustable
@@ -2359,6 +2361,7 @@ en:
     variant_to_add: Variant to add
     variant_to_be_received: Variant to be received
     variants: Variants
+    vat_id: VAT-ID
     version: Version
     view_product: View Product On Store
     void: Void

--- a/core/db/migrate/20250225051308_add_vat_id_email_and_reverse_charge_status_to_addresses.rb
+++ b/core/db/migrate/20250225051308_add_vat_id_email_and_reverse_charge_status_to_addresses.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddVatIdEmailAndReverseChargeStatusToAddresses < ActiveRecord::Migration[7.2]
+class AddVatIdEmailAndReverseChargeStatusToAddresses < ActiveRecord::Migration[7.0]
   def change
     add_column :spree_addresses, :vat_id, :string
     add_column :spree_addresses, :email, :string

--- a/core/db/migrate/20250225051308_add_vat_id_email_and_reverse_charge_status_to_addresses.rb
+++ b/core/db/migrate/20250225051308_add_vat_id_email_and_reverse_charge_status_to_addresses.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddVatIdEmailAndReverseChargeStatusToAddresses < ActiveRecord::Migration[7.2]
+  def change
+    add_column :spree_addresses, :vat_id, :string
+    add_column :spree_addresses, :email, :string
+    add_column :spree_addresses, :reverse_charge_status, :integer, default: 0, null: false,
+                comment: "Enum values: 0 = disabled, 1 = enabled, 2 = not_validated"
+  end
+end

--- a/core/lib/spree/permitted_attributes.rb
+++ b/core/lib/spree/permitted_attributes.rb
@@ -42,6 +42,7 @@ module Spree
     @@address_attributes = [
       :id, :name, :address1, :address2, :city, :country_id, :state_id,
       :zipcode, :phone, :state_name, :country_iso, :alternative_phone, :company,
+      :email, :vat_id, :reverse_charge_status,
       country: [:iso, :name, :iso3, :iso_name],
       state: [:name, :abbr]
     ]

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -294,4 +294,58 @@ RSpec.describe Spree::Address, type: :model do
 
     it { is_expected.to be_require_phone }
   end
+
+  describe 'enum reverse_charge_status' do
+    it 'defines the expected enum values' do
+      expect(Spree::Address.reverse_charge_statuses).to eq({
+        'disabled' => 0,
+        'enabled' => 1,
+        'not_validated' => 2
+      })
+    end
+
+    context 'allows valid values' do
+      it 'has not_validated value' do
+        address = build(:address)
+        # Updates the reverse_charge_status to "not_validated"
+        address.reverse_charge_status_not_validated!
+
+        expect(address).to be_valid
+      end
+
+      it 'has disabled value' do
+        address = build(:address)
+        # Updates the reverse_charge_status to "disabled"
+        address.reverse_charge_status_disabled!
+
+        expect(address).to be_valid
+      end
+
+      it 'has enabled value' do
+        address = build(:address)
+        # Updates the reverse_charge_status to "enabled"
+        address.reverse_charge_status_enabled!
+
+        expect(address).to be_valid
+      end
+    end
+
+    it 'raises an error for invalid values' do
+      expect { Spree::Address.new(reverse_charge_status: :invalid_status) }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'ensure fields are stored' do
+    let(:address) { build(:address) }
+
+    it 'saves email correctly' do
+      address.email = 'test@example.com'
+      expect(address.save).to be true
+    end
+
+    it 'saves vat_id correctly' do
+      address.vat_id = 'AB123'
+      expect(address.save).to be true
+    end
+  end
 end


### PR DESCRIPTION
**Description:**

This pull request introduces enhancements to the address handling logic in both the admin and API components by incorporating additional fields: email, VAT ID, and reverse charge status. These changes aim to improve the completeness of address data and enhance tax handling capabilities.

**Key Changes:**

1. **Admin Interface Updates:**
   - Added email, VAT ID, and reverse charge status fields to the address forms.
   - Updated form partials and views to handle these new fields.
   - Modified the JavaScript to process the new fields, ensuring proper functionality.

2. **API Enhancements:**
   - Updated `Spree::ApiConfiguration` to include email, VAT ID, and reverse charge status in the address attributes.
   - Modified `Spree::PermittedAttributes` to handle the new fields.
   - Enhanced request specs (`address_books_spec.rb` and `checkouts_spec.rb`) to verify the handling of the new attributes.

3. **Address Model Improvements:**
   - Introduced the new attributes (email, VAT ID, and reverse charge status) to the Address model.
   - Added an enum for reverse charge status to allow users to specify whether the status is enabled, disabled, or not validated.

- **Enhanced Data Completeness:** Storing email and VAT ID in the address model ensures that all relevant information is captured within the address record.
- **Improved Tax Handling:** The reverse charge status enum provides better handling and flexibility for tax-related settings, aligning with various tax requirements and user needs.


These changes enhance the functionality and completeness of the address handling logic by capturing additional relevant information and improving tax handling capabilities. The modifications ensure a more robust and flexible approach to managing address data within both the admin interface and the API.
