### PR TITLE
[Compliance] Add tax reverse charge mode

### DIFF
--- a/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/edit/component.html.erb
@@ -5,6 +5,13 @@
         <%= render component("ui/forms/field").text_field(f, :name) %>
         <%= render component("ui/forms/field").text_field(f, :tax_code) %>
         <%= render component("ui/forms/field").text_field(f, :description) %>
+        <% if Spree::Backend::Config.show_reverse_charge_fields %>
+          <%= render component("ui/forms/field").select(
+              f,
+              :tax_reverse_charge_mode,
+              Spree::TaxCategory.tax_reverse_charge_modes.keys.map { |key| [I18n.t("spree.tax_reverse_charge_modes.#{key}"), key] }
+            ) %>
+        <% end %>
         <label class="flex gap-2 items-center">
           <%= render component("ui/forms/checkbox").new(
               name: "#{f.object_name}[is_default]",

--- a/admin/app/components/solidus_admin/tax_categories/index/component.rb
+++ b/admin/app/components/solidus_admin/tax_categories/index/component.rb
@@ -46,7 +46,7 @@ class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Compo
   end
 
   def columns
-    [
+    columns = [
       {
         header: :name,
         data: ->(tax_category) do
@@ -82,5 +82,18 @@ class SolidusAdmin::TaxCategories::Index::Component < SolidusAdmin::Taxes::Compo
         },
       },
     ]
+
+    if Spree::Backend::Config.show_reverse_charge_fields
+      columns << {
+        header: :tax_reverse_charge_mode,
+        data: ->(tax_category) do
+          link_to_if tax_category.tax_reverse_charge_mode, I18n.t("spree.tax_reverse_charge_modes.#{tax_category.tax_reverse_charge_mode}"), edit_path(tax_category),
+            data: { turbo_frame: :resource_modal },
+            class: 'body-link'
+        end
+      }
+    end
+
+    columns
   end
 end

--- a/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
+++ b/admin/app/components/solidus_admin/tax_categories/new/component.html.erb
@@ -5,6 +5,13 @@
         <%= render component("ui/forms/field").text_field(f, :name) %>
         <%= render component("ui/forms/field").text_field(f, :tax_code) %>
         <%= render component("ui/forms/field").text_field(f, :description) %>
+        <% if Spree::Backend::Config.show_reverse_charge_fields %>
+          <%= render component("ui/forms/field").select(
+              f,
+              :tax_reverse_charge_mode,
+              Spree::TaxCategory.tax_reverse_charge_modes.keys.map { |key| [I18n.t("spree.tax_reverse_charge_modes.#{key}"), key] }
+            ) %>
+        <% end %>
         <label class="flex gap-2 items-center">
           <%= render component("ui/forms/checkbox").new(
               name: "#{f.object_name}[is_default]",

--- a/admin/app/controllers/solidus_admin/tax_categories_controller.rb
+++ b/admin/app/controllers/solidus_admin/tax_categories_controller.rb
@@ -7,7 +7,7 @@ module SolidusAdmin
     def resource_class = Spree::TaxCategory
 
     def permitted_resource_params
-      params.require(:tax_category).permit(:name, :description, :is_default, :tax_code)
+      params.require(:tax_category).permit(:name, :description, :is_default, :tax_code, :tax_reverse_charge_mode)
     end
   end
 end

--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -29,4 +29,16 @@
       <%= f.text_area :description, class: 'fullwidth' %>
     <% end %>
   </div>
+
+  <% if Spree::Backend::Config.show_reverse_charge_fields %>
+    <div class="col-4">
+      <%= f.field_container :tax_reverse_charge_mode do %>
+        <%= f.label :tax_reverse_charge_mode %>
+        <%= f.select :tax_reverse_charge_mode,
+            Spree::TaxCategory.tax_reverse_charge_modes.keys.map { |key| [I18n.t("spree.tax_reverse_charge_modes.#{key}"), key] },
+            { include_blank: false },
+            { class: 'custom-select fullwidth' } %>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -19,14 +19,20 @@
   <colgroup>
     <col style="width: 20%">
     <col style="width: 10%">
+    <% if Spree::Backend::Config.show_reverse_charge_fields %>
+      <col style="width: 10%">
+    <% end %>
     <col style="width: 40%">
-    <col style="width: 15%">
-    <col style="width: 15%">
+    <col style="width: 10%">
+    <col style="width: 10%">
   </colgroup>
   <thead>
     <tr data-hook="tax_header">
       <th><%= Spree::TaxCategory.human_attribute_name(:name) %></th>
       <th><%= Spree::TaxCategory.human_attribute_name(:tax_code) %></th>
+      <% if Spree::Backend::Config.show_reverse_charge_fields %>
+        <th><%= Spree::TaxCategory.human_attribute_name(:tax_reverse_charge_mode) %></th>
+      <% end %>
       <th><%= Spree::TaxCategory.human_attribute_name(:description) %></th>
       <th><%= Spree::TaxCategory.human_attribute_name(:is_default) %></th>
       <th class="actions"></th>
@@ -41,6 +47,9 @@
       <tr id="<%= spree_dom_id tax_category %>" data-hook="tax_row">
         <td><%= tax_category.name %></td>
         <td><%= tax_category.tax_code %></td>
+        <% if Spree::Backend::Config.show_reverse_charge_fields %>
+          <td><%= I18n.t("spree.tax_reverse_charge_modes.#{tax_category.tax_reverse_charge_mode}") %></td>
+        <% end %>
         <td><%= tax_category.description %></td>
         <td><%= tax_category.is_default? ? t('spree.say_yes') : t('spree.say_no') %></td>
         <td class="actions">

--- a/core/app/models/spree/tax_category.rb
+++ b/core/app/models/spree/tax_category.rb
@@ -10,6 +10,12 @@ module Spree
       self.tax_rate_tax_categories = []
     end
 
+    enum :tax_reverse_charge_mode, {
+      disabled: 0,
+      loose: 1,
+      strict: 2
+    }, prefix: true
+
     validates :name, presence: true
     validates_uniqueness_of :name, case_sensitive: true, unless: :deleted_at
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -392,6 +392,7 @@ en:
         is_default: Default
         name: Name
         tax_code: Tax Code
+        tax_reverse_charge_mode: Tax Reverse Charge Mode
       spree/tax_rate:
         amount: Rate
         expires_at: Expiration Date
@@ -2273,6 +2274,10 @@ en:
     tax_rate_amount_explanation: When using the "Default Tax" calculator, the amount is treated as a decimal amount to aid in calculations. (i.e. If the tax rate is 5% then enter 0.05) If using the "Flat Fee" calculator, the amount is used for the static fee.
     tax_rate_level: Tax Rate Level
     tax_rates: Tax Rates
+    tax_reverse_charge_modes:
+      disabled: Disabled
+      loose: Loose
+      strict: Strict
     taxon: Taxon
     taxon_attachment_removal_error: There was an error removing the attachment
     taxon_edit: Edit Taxon

--- a/core/db/migrate/20250226052907_add_tax_reverse_charge_mode_to_spree_tax_categories.rb
+++ b/core/db/migrate/20250226052907_add_tax_reverse_charge_mode_to_spree_tax_categories.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddTaxReverseChargeModeToSpreeTaxCategories < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_tax_categories, :tax_reverse_charge_mode, :integer, default: 0, null: false,
+               comment: "Enum values: 0 = disabled, 1 = loose, 2 = strict"
+  end
+end

--- a/core/spec/models/spree/tax_category_spec.rb
+++ b/core/spec/models/spree/tax_category_spec.rb
@@ -47,4 +47,34 @@ RSpec.describe Spree::TaxCategory, type: :model do
       end
     end
   end
+
+  describe 'enum tax_reverse_charge_mode' do
+    it 'defines the expected enum values' do
+      expect(Spree::TaxCategory.tax_reverse_charge_modes).to eq({
+        'disabled' => 0,
+        'loose' => 1,
+        'strict' => 2
+      })
+    end
+
+    it 'allows valid values' do
+      tax_category = build(:tax_category)
+      # Updates the tax_reverse_charge_mode to "strict"
+      expect(tax_category).to be_valid
+      tax_category.tax_reverse_charge_mode_strict!
+
+      # Updates the tax_reverse_charge_mode to "loose"
+      expect(tax_category).to be_valid
+      tax_category.tax_reverse_charge_mode_loose!
+      expect(tax_category).to be_valid
+
+      # Updates the tax_reverse_charge_mode to "disabled"
+      tax_category.tax_reverse_charge_mode_disabled!
+      expect(tax_category).to be_valid
+    end
+
+    it 'raises an error for invalid values' do
+      expect { Spree::TaxCategory.new(tax_reverse_charge_mode: :invalid_status) }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
### Description

This pull request introduces enhancements to the tax applicability logic and updates the admin interface to support the new functionality.

#### Changes:

1. **Tax Applicability Logic**:
    - Introduced the `tax_applicable?` method in the `Spree::Tax::TaxHelpers` module. This method determines if tax is applicable based on the `tax_reverse_charge_mode` of the tax category and the `reverse_charge_status` of the address. The `rates_for_item` method has been updated to use this new logic, ensuring that only applicable tax rates are selected.
    - The `tax_applicable?` method supports three modes:
        - **strict**: Tax applies if the address reverse_charge_status **is not equal to** enabled (reverse charge).
        - **loose**: Tax applies if the address reverse_charge_status **is not equal to** disabled.
        - **disabled**: Tax always applies.

2. **Admin Interface Updates**:
    - Updated the admin interface to allow users to select the `tax_reverse_charge_mode` when creating or editing tax categories. The permitted parameters in the `TaxCategoriesController` have been updated to include `tax_reverse_charge_mode`.
    - The admin views and components have been updated to display the `tax_reverse_charge_mode` in the tax categories index and form views. This ensures that users can easily manage and view the reverse charge mode for each tax category.

3. **Model and Spec Updates**:
    - Introduced the `tax_reverse_charge_mode` enum to the `Spree::TaxCategory` model, with values `disabled`, `loose`, and `strict`. This change includes a migration to add the `tax_reverse_charge_mode` column to the `spree_tax_categories` table, with a default value of `0` (disabled). Additionally, the English locale file has been updated to include translations for the new enum values.
    - The related specs have been updated to test the new enum values and ensure that the `tax_reverse_charge_mode` is correctly validated and applied.


The `tax_reverse_charge_mode` enum allows for more granular control over tax applicability based on the reverse charge status of an address. This enhancement improves the flexibility and accuracy of tax calculations by enabling different tax handling modes. The updates to the admin interface ensure that users can easily manage and view the reverse charge mode for each tax category, providing a better user experience.

